### PR TITLE
Add first draft of contribution instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,42 @@ Builds the app for production to the build folder.<br>
 It correctly bundles React in production mode and optimizes the build for the best performance.
 
 The build is minified and the filenames include the hashes.
+
+## Contributing
+
+[![Waffle.io - Columns and their card count](https://badge.waffle.io/CodeForBoulder/upswyng.svg?columns=all)](https://waffle.io/CodeForBoulder/upswyng)
+
+### 1. Find an Issue Pending Development, Needing Help, or Asking a Question
+
+Want to develop? All issues that have been approved for development, but have not been started will be labelled as **Status: Pending**.
+
+We'd love your input on possible new features. Some issues aren't ready for development and won't have a status label. These issues may need more input before being approved and instead be labelled **Type: Help Wanted**.
+
+Maybe you have the answer to someone's question. Look through any issues labelled with **Type: Help Wanted** and comment with your answer.
+
+### 2. Work on an Issue
+
+Once you have have found an issue you feel comfortable working on, request to work on the issue and we'll label the issue as **Status: In Progress** to make sure others don't work on it as well.
+
+Then, create a new branch off the current `master`.
+
+#### Branch Naming
+
+All feature branch names will begin with a group-token followed by a short name describing what the branch addresses.
+
+Below are approved group-tokens:
+
+-  **`add/`** : identifies a branch that *adds* a feature
+-  **`updt/`** : identifies a branch that *updates* a feature. This is useful for features whose original feature branches were deleted, or have already been merged with the master branch.
+-  **`rmv/`** : identifies a branch that *removes* a feature.
+-  **`exp/`** : identifies a branch that *experiments* with creating a new feature without plans of implementation.
+
+For example, if you wanted to create a branch that update the way a service was displayed, you could name the branch **`updt/service-display`**.
+
+### 3. Create a Pull Request (PR)
+
+Once you believe your feature is ready for production, create a PR and reference what issue this addresses in the PR's description.
+
+If there any updates requested, please make those updates on your local branch and re-push that branch to the repository.
+
+If approved, project managers will handle merging and deploying.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ Then, create a new branch off the current `master`.
 
 #### Branch Naming
 
-All feature branch names will begin with a group-token followed by a short name describing what the branch addresses.
+All feature branch names will begin with a group-token, be proceed by a short name describing what the branch addresses, and finally end with the issue this branch addresses.
+
+**`grouptoken/short-name-#issuenumber`**
 
 Below are approved group-tokens:
 
@@ -60,7 +62,7 @@ Below are approved group-tokens:
 -  **`rmv/`** : identifies a branch that *removes* a feature.
 -  **`exp/`** : identifies a branch that *experiments* with creating a new feature without plans of implementation.
 
-For example, if you wanted to create a branch that update the way a service was displayed, you could name the branch **`updt/service-display`**.
+For example, if you wanted to create a branch that update the way a service was displayed which is described in issue 36, you could name the branch **`updt/service-display-#36`**.
 
 ### 3. Create a Pull Request (PR)
 


### PR DESCRIPTION
This updates the README with a rough draft of contributing instructions #7. I wanted to explain the use of labels for the Waffle.io integration as well as provide an option for branch naming.

I'm not really married to naming convention I provided, so let me know if you want to go a different direction.