### PR TITLE
Implement initial header containing menu button and logo.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1157,6 +1157,15 @@
         }
       }
     },
+    "@material-ui/icons": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-3.0.2.tgz",
+      "integrity": "sha512-QY/3gJnObZQ3O/e6WjH+0ah2M3MOgLOzCy8HTUoUx9B6dDrS18vP7Ycw3qrDEKlB6q1KNxy6CZHm5FCauWGy2g==",
+      "requires": {
+        "@babel/runtime": "^7.2.0",
+        "recompose": "0.28.0 - 0.30.0"
+      }
+    },
     "@material-ui/system": {
       "version": "3.0.0-alpha.2",
       "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-3.0.0-alpha.2.tgz",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@material-ui/core": "^3.9.2",
+    "@material-ui/icons": "^3.0.2",
     "firebase": "^5.8.4",
     "react": "^16.8.3",
     "react-dom": "^16.8.3",

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
 import './App.css';
+import Header from './Header';
 
 class App extends Component {
   render() {
@@ -14,8 +15,7 @@ class App extends Component {
 
 const Home = () => (
   <div className="home">
-    <h1>upswyng</h1>
-    <p>Home placeholder</p>
+    <Header />
   </div>
 );
 

--- a/src/Header.js
+++ b/src/Header.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import AppBar from '@material-ui/core/AppBar';
+import Toolbar from '@material-ui/core/Toolbar';
+import IconButton from '@material-ui/core/IconButton';
+import MenuIcon from '@material-ui/icons/Menu';
+import { Link } from 'react-router-dom';
+
+const onMenuClick = e => {
+  //handle when the menu button is clicked here
+};
+
+function Header(props) {
+  return (
+    <header>
+      <AppBar position="static">
+        <Toolbar>
+          <IconButton color="inherit" onClick={onMenuClick} aria-label="Menu">
+            <MenuIcon />
+          </IconButton>
+          <Link to="/">
+            <img src="https://via.placeholder.com/150x50" alt="UpSwyng" />
+          </Link>
+        </Toolbar>
+      </AppBar>
+    </header>
+  );
+}
+
+export default Header;


### PR DESCRIPTION
This PR closes #27 

## What does this PR do?

- Add @material-ui/icons as a dependency to use built-in icons.
- Creates a new `Header` component using Material UI components