### PR TITLE
Add getSearchParam utility

### DIFF
--- a/src/utils/searchParams.test.js
+++ b/src/utils/searchParams.test.js
@@ -37,7 +37,7 @@ describe('getSearchParamVal()', () => {
   });
 
   describe('when the search parameter exists but does not have a value', () => {
-    it('returns null', () => {
+    it('returns any empty string', () => {
       mockSearchParamName = 'searchParamWithoutValue';
       mockSearch = `?${mockSearchParamName}`;
 
@@ -45,7 +45,7 @@ describe('getSearchParamVal()', () => {
 
       searchParamVal = getSearchParamVal(mockSearchParamName);
 
-      expect(searchParamVal).toBeNull();
+      expect(searchParamVal).toBe('');
     });
   });
 });

--- a/src/utils/searchParams.test.js
+++ b/src/utils/searchParams.test.js
@@ -1,0 +1,51 @@
+import { getSearchParamVal } from './searchParams';
+
+describe('getSearchParamVal()', () => {
+  let mockSearchParamName;
+  let mockSearchParamVal;
+  let mockSearch;
+
+  let searchParamVal;
+
+  beforeEach(() => {
+    history.replaceState({}, 'Page with no Search Parameters', '/');
+  });
+
+  it('returns the value of the provided search parameter', () => {
+    mockSearchParamName = 'the-name-of-the-search-param';
+    mockSearchParamVal = 'the-value-of-the-search-param';
+
+    mockSearch = `?${mockSearchParamName}=${mockSearchParamVal}`;
+    history.replaceState({}, 'Some Page', `/some-page${mockSearch}`);
+
+    searchParamVal = getSearchParamVal(mockSearchParamName);
+
+    expect(searchParamVal).toBe(mockSearchParamVal);
+  });
+
+  describe('when the search parameter does not exist in the url', () => {
+    it('returns null', () => {
+      mockSearchParamName = 'I-should-not-exist-as-a-search-parameter';
+      mockSearch = `?some-other-search-parameter=some-value`;
+
+      history.replaceState({}, 'Some Page', `/some-page${mockSearch}`);
+
+      searchParamVal = getSearchParamVal(mockSearchParamName);
+
+      expect(searchParamVal).toBeNull();
+    });
+  });
+
+  describe('when the search parameter exists but does not have a value', () => {
+    it('returns null', () => {
+      mockSearchParamName = 'searchParamWithoutValue';
+      mockSearch = `?${mockSearchParamName}`;
+
+      history.replaceState({}, 'Some Page', `some-page${mockSearch}`);
+
+      searchParamVal = getSearchParamVal(mockSearchParamName);
+
+      expect(searchParamVal).toBeNull();
+    });
+  });
+});

--- a/src/utils/searchParams.ts
+++ b/src/utils/searchParams.ts
@@ -1,0 +1,5 @@
+export const getSearchParamVal = (paramName: string) => {
+  const allSearchParams = new URLSearchParams(location.search);
+
+  return allSearchParams.get(paramName) || null;
+};

--- a/src/utils/searchParams.ts
+++ b/src/utils/searchParams.ts
@@ -1,5 +1,5 @@
 export const getSearchParamVal = (paramName: string): string | null => {
   const allSearchParams = new URLSearchParams(location.search);
 
-  return allSearchParams.get(paramName) || null;
+  return allSearchParams.get(paramName);
 };

--- a/src/utils/searchParams.ts
+++ b/src/utils/searchParams.ts
@@ -1,4 +1,4 @@
-export const getSearchParamVal = (paramName: string) => {
+export const getSearchParamVal = (paramName: string): string | null => {
   const allSearchParams = new URLSearchParams(location.search);
 
   return allSearchParams.get(paramName) || null;


### PR DESCRIPTION
This PR does not address an issue.

## What does this PR do?

Adds a `getSearchParam` utility that can be used to grab the value of a URL search parameter. If the parameter does not exist or has no value, the utility will return `null`.

This utility will eventually be used in a future PR to grab a resource's ID from the URL.

## How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/12zV7u6Bh0vHpu/giphy.gif)
