### PR TITLE
Add convertPixelsToRems() helper

### DIFF
--- a/src/App.styles.ts
+++ b/src/App.styles.ts
@@ -22,12 +22,18 @@ export const colors = {
   white: '#FFF'
 };
 
-export const fonts = {
-  openSans: "'Open Sans', sans-serif"
+const baseFontSize = 16;
+const baseFontSizePercent = (16 / baseFontSize) * 100;
+export const font = {
+  sizes: {
+    base: baseFontSize,
+    basePixels: `${baseFontSize}px`,
+    basePercent: `${baseFontSizePercent}%`
+  },
+  families: {
+    openSans: "'Open Sans', sans-serif"
+  }
 };
-
-const baseFontSizePixels = 16;
-const baseFontSizePercent = 16 / baseFontSizePixels;
 
 export const ScreenReaderOnly = css`
   clip: rect(1px, 1px, 1px, 1px);
@@ -61,8 +67,8 @@ export default createGlobalStyle`
   body {
     background: ${colors.charcoal};
     color: ${colors.white};
-    font-family: ${fonts.openSans};
-    font-size: ${baseFontSizePercent};
+    font-family: ${font.families.openSans};
+    font-size: ${font.sizes.basePercent};
   }
   a {
     ${aStyles}

--- a/src/App.styles.ts
+++ b/src/App.styles.ts
@@ -34,7 +34,7 @@ export const font = {
     openSans: "'Open Sans', sans-serif"
   },
   helpers: {
-    convertPixelsToRems: (value: number): string => `${baseFontSize / value}rem`
+    convertPixelsToRems: (value: number): string => `${value / baseFontSize}rem`
   }
 };
 
@@ -60,7 +60,7 @@ export const aStyles = css`
 
 export const Container = styled(Grid)`
   margin: 0 auto;
-  max-width: 480px;
+  max-width: ${font.helpers.convertPixelsToRems(480)};
 ` as typeof Grid;
 
 export default createGlobalStyle`

--- a/src/App.styles.ts
+++ b/src/App.styles.ts
@@ -26,6 +26,9 @@ export const fonts = {
   openSans: "'Open Sans', sans-serif"
 };
 
+const baseFontSizePixels = 16;
+const baseFontSizePercent = 16 / baseFontSizePixels;
+
 export const ScreenReaderOnly = css`
   clip: rect(1px, 1px, 1px, 1px);
   clip-path: inset(50%);
@@ -59,6 +62,7 @@ export default createGlobalStyle`
     background: ${colors.charcoal};
     color: ${colors.white};
     font-family: ${fonts.openSans};
+    font-size: ${baseFontSizePercent};
   }
   a {
     ${aStyles}

--- a/src/App.styles.ts
+++ b/src/App.styles.ts
@@ -32,6 +32,9 @@ export const font = {
   },
   families: {
     openSans: "'Open Sans', sans-serif"
+  },
+  helpers: {
+    convertPixelsToRems: (value: number): string => `${baseFontSize / value}rem`
   }
 };
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,7 +8,7 @@ import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 import Logo from './Logo';
-import { Container } from '../App.styles';
+import { Container, font } from '../App.styles';
 
 const headerVerticalMargin = 24;
 
@@ -16,14 +16,16 @@ const StyledHeader = styled(AppBar)`
   && {
     background: none;
     box-shadow: none;
-    margin-bottom: ${headerVerticalMargin / 2}px;
-    margin-top: ${headerVerticalMargin}px;
+    margin-bottom: ${font.helpers.convertPixelsToRems(
+      headerVerticalMargin / 2
+    )};
+    margin-top: ${font.helpers.convertPixelsToRems(headerVerticalMargin)};
   }
 ` as typeof AppBar;
 
 const StyledMenuButton = styled(IconButton)`
   && {
-    margin-left: -12px;
+    margin-left: ${font.helpers.convertPixelsToRems(-12)};
   }
 ` as typeof IconButton;
 

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { Grid } from '@material-ui/core';
 import styled from 'styled-components';
 import HomeButtons from './HomeButtons';
-import { Container } from '../App.styles';
+import { Container, font } from '../App.styles';
 import Search from './Search';
 
 const HomeButtonsContainer = styled(Grid)`
   && {
-    margin-bottom: 30px;
-    margin-top: 15px;
+    margin-bottom: ${font.helpers.convertPixelsToRems(30)};
+    margin-top: ${font.helpers.convertPixelsToRems(15)};
   }
 ` as typeof Grid;
 

--- a/src/components/HomeButton.tsx
+++ b/src/components/HomeButton.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Button } from '@material-ui/core';
 import { ButtonProps } from '@material-ui/core/Button';
 import styled from 'styled-components';
-import { colors, fonts } from '../App.styles';
+import { colors, font } from '../App.styles';
 
 interface HomeLinkPropsBase {
   children: React.ReactElement | React.ReactElement[];
@@ -24,7 +24,7 @@ const HomeButton = styled((props: HomeButtonProps) => {
     border-radius: 0;
     color: ${colors.white};
     display: flex;
-    padding: 10px;
+    padding: ${font.helpers.convertPixelsToRems(10)};
     text-decoration: none;
     width: 100%;
   }
@@ -37,18 +37,18 @@ const HomeButton = styled((props: HomeButtonProps) => {
     align-items: flex-start;
     display: flex;
     flex-direction: column;
-    font-family: ${fonts.openSans};
-    font-size: 22px;
+    font-family: ${font.families.openSans};
+    font-size: ${font.helpers.convertPixelsToRems(22)};
     font-weight: 700;
     justify-content: space-between;
-    line-height: 24px;
+    line-height: ${font.helpers.convertPixelsToRems(24)};
     text-transform: none;
   }
   svg {
     align-self: flex-end;
     height: auto;
-    max-height: 45px;
-    width: 42px;
+    max-height: ${font.helpers.convertPixelsToRems(45)};
+    width: ${font.helpers.convertPixelsToRems(42)};
   }
 `;
 

--- a/src/components/HomeButtons.tsx
+++ b/src/components/HomeButtons.tsx
@@ -15,7 +15,7 @@ import {
 import { THomeButtonAnchor, THomeButtonRouterLink } from '../types';
 import { HomeRouterLink, HomeAnchorLink } from './HomeLink';
 import HomeButton from './HomeButton';
-import { colors, font } from '../App.styles';
+import { colors } from '../App.styles';
 
 const routerLinkButtons: THomeButtonRouterLink[] = [
   {
@@ -107,51 +107,6 @@ const coordinatedEntryButton: THomeButtonAnchor = {
   color: colors.rosewood,
   target: '_blank'
 };
-const HomeLink = styled(Link)`
-  text-decoration: none;
-`;
-
-interface HomeButtonProps extends ButtonProps {
-  readonly buttonColor: string;
-}
-
-const HomeButton = styled((props: HomeButtonProps) => {
-  return <Button {...props} />;
-})`
-  && {
-    align-items: stretch;
-    background: ${(props: HomeButtonProps) =>
-      props.buttonColor || colors.greyDark};
-    border-radius: 0;
-    color: ${colors.white};
-    display: flex;
-    height: 100%;
-    padding: ${font.helpers.convertPixelsToRems(10)};
-    text-decoration: none;
-    width: 100%;
-  }
-  &&:hover {
-    background: ${(props: HomeButtonProps) =>
-      props.buttonColor || colors.greyDark};
-    filter: brightness(95%);
-  }
-  > span {
-    align-items: flex-start;
-    display: flex;
-    flex-direction: column;
-    font-family: ${font.families.openSans};
-    font-size: ${font.helpers.convertPixelsToRems(22)};
-    font-weight: 700;
-    justify-content: space-between;
-    line-height: ${font.helpers.convertPixelsToRems(24)};
-    text-transform: none;
-  }
-  svg {
-    align-self: flex-end;
-    height: auto;
-    width: ${font.helpers.convertPixelsToRems(42)};
-  }
-`;
 
 const HomeButtons = () => (
   <>

--- a/src/components/HomeButtons.tsx
+++ b/src/components/HomeButtons.tsx
@@ -126,7 +126,7 @@ const HomeButton = styled((props: HomeButtonProps) => {
     color: ${colors.white};
     display: flex;
     height: 100%;
-    padding: 10px;
+    padding: ${font.helpers.convertPixelsToRems(10)};
     text-decoration: none;
     width: 100%;
   }
@@ -140,16 +140,16 @@ const HomeButton = styled((props: HomeButtonProps) => {
     display: flex;
     flex-direction: column;
     font-family: ${font.families.openSans};
-    font-size: 22px;
+    font-size: ${font.helpers.convertPixelsToRems(22)};
     font-weight: 700;
     justify-content: space-between;
-    line-height: 24px;
+    line-height: ${font.helpers.convertPixelsToRems(24)};
     text-transform: none;
   }
   svg {
     align-self: flex-end;
     height: auto;
-    width: 42px;
+    width: ${font.helpers.convertPixelsToRems(42)};
   }
 `;
 

--- a/src/components/HomeButtons.tsx
+++ b/src/components/HomeButtons.tsx
@@ -13,9 +13,9 @@ import {
   WifiIcon
 } from './Icons';
 import { THomeButtonAnchor, THomeButtonRouterLink } from '../types';
-import { colors } from '../App.styles';
 import { HomeRouterLink, HomeAnchorLink } from './HomeLink';
 import HomeButton from './HomeButton';
+import { colors, font } from '../App.styles';
 
 const routerLinkButtons: THomeButtonRouterLink[] = [
   {
@@ -107,6 +107,51 @@ const coordinatedEntryButton: THomeButtonAnchor = {
   color: colors.rosewood,
   target: '_blank'
 };
+const HomeLink = styled(Link)`
+  text-decoration: none;
+`;
+
+interface HomeButtonProps extends ButtonProps {
+  readonly buttonColor: string;
+}
+
+const HomeButton = styled((props: HomeButtonProps) => {
+  return <Button {...props} />;
+})`
+  && {
+    align-items: stretch;
+    background: ${(props: HomeButtonProps) =>
+      props.buttonColor || colors.greyDark};
+    border-radius: 0;
+    color: ${colors.white};
+    display: flex;
+    height: 100%;
+    padding: 10px;
+    text-decoration: none;
+    width: 100%;
+  }
+  &&:hover {
+    background: ${(props: HomeButtonProps) =>
+      props.buttonColor || colors.greyDark};
+    filter: brightness(95%);
+  }
+  > span {
+    align-items: flex-start;
+    display: flex;
+    flex-direction: column;
+    font-family: ${font.families.openSans};
+    font-size: 22px;
+    font-weight: 700;
+    justify-content: space-between;
+    line-height: 24px;
+    text-transform: none;
+  }
+  svg {
+    align-self: flex-end;
+    height: auto;
+    width: 42px;
+  }
+`;
 
 const HomeButtons = () => (
   <>

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -22,7 +22,9 @@ const SearchInput = styled(TextField)`
   input {
     font-family: ${font.families.openSans};
     font-size: 1em;
-    padding: 7px 7px 7px 0;
+    padding: ${font.helpers.convertPixelsToRems(7)}
+      ${font.helpers.convertPixelsToRems(7)}
+      ${font.helpers.convertPixelsToRems(7)} 0;
   }
   input::placeholder {
     color: ${colors.black};
@@ -32,12 +34,12 @@ const SearchInput = styled(TextField)`
 
 const SearchAdornment = styled(InputAdornment)`
   && {
-    margin-left: 7px;
-    margin-right: 7px;
+    margin-left: ${font.helpers.convertPixelsToRems(7)};
+    margin-right: ${font.helpers.convertPixelsToRems(7)};
   }
   svg {
-    width: 0.75em;
-    height: 0.75em;
+    width: ${font.helpers.convertPixelsToRems(18)};
+    height: ${font.helpers.convertPixelsToRems(18)};
   }
 ` as typeof InputAdornment;
 

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -5,7 +5,7 @@ import { Redirect } from 'react-router';
 import styled from 'styled-components';
 
 import { SEARCH_PARAM_QUERY } from '../constants';
-import { colors, fonts, ScreenReaderOnly } from '../App.styles';
+import { colors, font, ScreenReaderOnly } from '../App.styles';
 
 const SearchInput = styled(TextField)`
   && {
@@ -20,7 +20,7 @@ const SearchInput = styled(TextField)`
     ${ScreenReaderOnly}
   }
   input {
-    font-family: ${fonts.openSans};
+    font-family: ${font.families.openSans};
     font-size: 1em;
     padding: 7px 7px 7px 0;
   }


### PR DESCRIPTION
This PR doesn't close an issue.

## What does this PR do?
- restructures the `font` object in App.styles
- implements a `convertPixelsToRems()` helper in the `font` object that will do as it's named
- updates and usage of pixels in styles to use rems (via `convertPixelsToRems`)

I'm not sure if the helper itself should live inside the font object, but let me know what you think.

## How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![can I help you with something?](https://media.giphy.com/media/26DMXR2zOUFCkxSPm/giphy.gif)
