### PR TITLE
Fix loading spinner on individual service page

### DIFF
--- a/src/components/Resource.test.tsx
+++ b/src/components/Resource.test.tsx
@@ -28,21 +28,10 @@ describe('<Resource/>', () => {
     expect(wrapper.find('h1').text()).toBe(foodResource.charityname);
   });
 
-  it('renders nothing when a resource is not loaded', () => {
+  it('renders a loading spinner when a resource is not loaded', () => {
     mockedUseResource.mockImplementation(() => null) as typeof jest.mock;
     const wrapper = shallow(<Resource />);
 
-    expect(wrapper.isEmptyRender).toBeTruthy();
-  });
-
-  describe('when it is passed a blank resource', () => {
-    mockedUseResource.mockImplementation(
-      () => blankResource
-    ) as typeof jest.mock;
-    const wrapper = shallow(<Resource />);
-
-    it('renders a <LoadingSpinner/>', () => {
-      expect(wrapper.find('LoadingSpinner').length).toBe(1);
-    });
+    expect(wrapper.find('LoadingSpinner').length).toBe(1);
   });
 });

--- a/src/components/Resource.tsx
+++ b/src/components/Resource.tsx
@@ -35,14 +35,10 @@ export const Resource = () => {
   const resource = useResource(resourceDataRef);
 
   if (!resource) {
-    return null;
+    return <LoadingSpinner />;
   }
 
   const { charityname, schedule } = resource;
-
-  if (!charityname) {
-    return <LoadingSpinner />;
-  }
 
   return (
     <Container>


### PR DESCRIPTION
This PR does not close an issue.

## What does this PR do?

- updates the loading spinner to be rendered when no resource is present
- updates the corresponding test

## How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![I can fix that](https://media.giphy.com/media/noPJ38LkojKla/giphy.gif)
