### PR TITLE
add back button and banner to resource

### DIFF
--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Icon, Typography } from '@material-ui/core';
+import { ArrowBack } from '@material-ui/icons';
+import { createBrowserHistory } from 'history';
+import styled from 'styled-components';
+
+import { font } from '../App.styles';
+
+const CategoryBannerLink = styled.a`
+  align-items: center;
+  display: flex;
+  padding-right: ${font.helpers.convertPixelsToRems(12)};
+`;
+
+const CategoryBannerIcon = styled(Icon)`
+  && {
+    align-items: center;
+    display: flex;
+    font-size: ${font.helpers.convertPixelsToRems(36)};
+    height: auto;
+    width: auto;
+  }
+` as typeof Icon;
+
+const CategoryBannerArrowBack = styled(ArrowBack)`
+  && {
+    font-size: inherit;
+  }
+` as typeof ArrowBack;
+
+const customHistory = createBrowserHistory();
+
+const BackButton = () => (
+  <CategoryBannerLink onClick={() => customHistory.goBack()}>
+    <Typography variant="srOnly">go back to pervious page</Typography>
+    <CategoryBannerIcon>
+      <CategoryBannerArrowBack />
+    </CategoryBannerIcon>
+  </CategoryBannerLink>
+);
+
+export default BackButton;

--- a/src/components/CategoryBanner.tsx
+++ b/src/components/CategoryBanner.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import styled from 'styled-components';
-import { Icon } from '@material-ui/core';
-import { ArrowBack } from '@material-ui/icons';
+
 import { colors, font } from '../App.styles';
+import BackButton from './BackButton';
 
 interface Props {
   color?: string;
@@ -19,28 +18,6 @@ const CategoryBannerContainer = styled.div`
   wrap: no-wrap;
 `;
 
-const CategoryBannerLink = styled(Link)`
-  align-items: center;
-  display: flex;
-  padding-right: ${font.helpers.convertPixelsToRems(12)};
-`;
-
-const CategoryBannerIcon = styled(Icon)`
-  && {
-    align-items: center;
-    display: flex;
-    font-size: ${font.helpers.convertPixelsToRems(36)};
-    height: auto;
-    width: auto;
-  }
-` as typeof Icon;
-
-const CategoryBannerArrowBack = styled(ArrowBack)`
-  && {
-    font-size: inherit;
-  }
-` as typeof ArrowBack;
-
 const CategoryBannerHeading = styled.h1`
   align-items: center;
   display: flex;
@@ -51,11 +28,7 @@ const CategoryBannerHeading = styled.h1`
 
 const CategoryBanner = ({ color, text }: Props) => (
   <CategoryBannerContainer color={color}>
-    <CategoryBannerLink to="/">
-      <CategoryBannerIcon>
-        <CategoryBannerArrowBack />
-      </CategoryBannerIcon>
-    </CategoryBannerLink>
+    <BackButton />
     <CategoryBannerHeading>{text}</CategoryBannerHeading>
   </CategoryBannerContainer>
 );

--- a/src/components/CategoryResults.tsx
+++ b/src/components/CategoryResults.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { TResourceCategory } from '../types';
 import useSearchResults from './useSearchResults';
-import CategoryBanner from './CategoryBanner';
+import PageBanner from './PageBanner';
 import SubCategories from './SubCategories';
 import SearchResults from './SearchResults';
 
@@ -24,7 +24,7 @@ const CategoryResults = ({
 
   return (
     <>
-      <CategoryBanner text={categoryText} color={categoryColor} />
+      <PageBanner text={categoryText} color={categoryColor} />
       <SubCategories
         category={category}
         color={categoryColor}

--- a/src/components/Details.tsx
+++ b/src/components/Details.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
-import { colors } from '../App.styles';
+import { colors, font } from '../App.styles';
 
 interface DetailsProps {
   children: React.ReactChild | React.ReactChild[];
@@ -11,6 +11,7 @@ export const StyledDetails = styled.div`
   flex-wrap: wrap;
   font-size: 14px;
   line-height: 1;
+  margin-top: ${font.helpers.convertPixelsToRems(30)};
 `;
 
 export const DetailItemStyles = css`

--- a/src/components/PageBanner.tsx
+++ b/src/components/PageBanner.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 const CategoryBannerContainer = styled.div`
   align-items: stretch;
-  background: ${props => (props.color ? props.color : colors.greyLight)};
+  background: ${props => (props.color ? props.color : colors.greyMedium)};
   display: flex;
   flex-direction: row;
   padding: ${font.helpers.convertPixelsToRems(14)} 0;

--- a/src/components/PageBanner.tsx
+++ b/src/components/PageBanner.tsx
@@ -9,7 +9,7 @@ interface Props {
   text: string;
 }
 
-const CategoryBannerContainer = styled.div`
+const PageBannerContainer = styled.div`
   align-items: stretch;
   background: ${props => (props.color ? props.color : colors.greyMedium)};
   display: flex;
@@ -18,7 +18,7 @@ const CategoryBannerContainer = styled.div`
   wrap: no-wrap;
 `;
 
-const CategoryBannerHeading = styled.h1`
+const PageBannerHeading = styled.h1`
   align-items: center;
   display: flex;
   font-size: ${font.helpers.convertPixelsToRems(24)};
@@ -26,11 +26,11 @@ const CategoryBannerHeading = styled.h1`
   margin: ${font.helpers.convertPixelsToRems(-2)} 0 0;
 `;
 
-const CategoryBanner = ({ color, text }: Props) => (
-  <CategoryBannerContainer color={color}>
+const PageBanner = ({ color, text }: Props) => (
+  <PageBannerContainer color={color}>
     <BackButton />
-    <CategoryBannerHeading>{text}</CategoryBannerHeading>
-  </CategoryBannerContainer>
+    <PageBannerHeading>{text}</PageBannerHeading>
+  </PageBannerContainer>
 );
 
-export default CategoryBanner;
+export default PageBanner;

--- a/src/components/Resource.tsx
+++ b/src/components/Resource.tsx
@@ -3,7 +3,9 @@ import { TResource } from '../types';
 import useResource from './useResource';
 import { getSearchParamVal } from '../utils/searchParams';
 import { SEARCH_PARAM_RESOURCE, FIREBASE_RESOURCE_BRANCH } from '../constants';
+
 import LoadingSpinner from './LoadingSpinner';
+import PageBanner from './PageBanner';
 import { Container } from '../App.styles';
 import Details, { DetailBody, DetailHeading } from './Details';
 import Schedule from './Schedule';
@@ -48,7 +50,7 @@ export const Resource = () => {
 
   return (
     <Container>
-      <h1>{charityname}</h1>
+      <PageBanner text={charityname} />
       <Details>
         <DetailHeading>Address</DetailHeading>
         <DetailBody>{renderAddressContent(resource)}</DetailBody>

--- a/src/components/__tests__/Resource.test.tsx
+++ b/src/components/__tests__/Resource.test.tsx
@@ -26,6 +26,7 @@ jest.mock('../../App.styles', () => ({
 jest.mock('../../utils/searchParams', () => ({
   getSearchParamVal: () => 'some resource ID'
 }));
+jest.mock('../PageBanner', () => 'PageBanner');
 jest.mock('../Details', () => ({
   __esModule: true,
   default: 'Details',
@@ -40,7 +41,9 @@ describe('<Resource/>', () => {
   const wrapper = shallow(<Resource />);
 
   it('renders the charityname property of the resource prop object', () => {
-    expect(wrapper.find('h1').text()).toBe(foodResource.charityname);
+    expect(wrapper.find('PageBanner').prop('text')).toBe(
+      foodResource.charityname
+    );
   });
 
   it('renders a map component', () => {


### PR DESCRIPTION
This PR does not close an issue.

## What does this PR do?

- creates a `<BackButton/>` component
- adds a back button to an individual resource page
- replaces current back button found on category page with new component
- adds a page banner similar to the one found on the category page

## Before

<img width="500" alt="resource title without back button and banner" src="https://user-images.githubusercontent.com/6598084/65835453-7b701380-e2a3-11e9-80e7-eb067718e7db.png">

## After

<img width="500" alt="resource title with back button and banner" src="https://user-images.githubusercontent.com/6598084/65835451-7ad77d00-e2a3-11e9-987e-44193c819451.png">

## How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![I have to go back](https://media.giphy.com/media/d3ML0Njo9yIYdjws/giphy.gif)
