### PR TITLE
fix overflow issue with SubCategories

### DIFF
--- a/src/components/SubCategories.tsx
+++ b/src/components/SubCategories.tsx
@@ -16,8 +16,10 @@ const subCategoryHorizontalSpacing = 5;
 const SubCategoriesList = styled.ul`
   display: flex;
   flex-direction: row;
-  margin: 0 ${font.helpers.convertPixelsToRems(-subCategoryHorizontalSpacing)};
-  padding: ${font.helpers.convertPixelsToRems(20)} 0
+  margin: ${font.helpers.convertPixelsToRems(10)}
+    ${font.helpers.convertPixelsToRems(-subCategoryHorizontalSpacing)} 0;
+  overflow-x: scroll;
+  padding: ${font.helpers.convertPixelsToRems(10)} 0
     ${font.helpers.convertPixelsToRems(10)};
   width: auto;
 `;


### PR DESCRIPTION
This PR does not close an issue.

## What does this PR do?

- updates the sub-category selector to overflow-x via scroll
- updates the horizontal padding on the sub-category container to be equal while maintaining perceived spacing via margin

I think some design work may be needed in the future for ensuring it's obvious there is more content to the right, but this is a step in the right direction.

## How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![lets scroll](https://media.giphy.com/media/xT5LMMjQXvcTi1xh0Q/giphy.gif)
