### PR TITLE
fix home page buttons not stretching

### DIFF
--- a/src/components/HomeLink.tsx
+++ b/src/components/HomeLink.tsx
@@ -12,7 +12,8 @@ type HomeRouterLinkProps = HomeLinkPropsBase & THomeButtonRouterLink;
 type HomeAnchorProps = HomeLinkPropsBase & THomeButtonAnchor;
 
 const HomeLinkStyles = css`
-  display: block;
+  align-items: stretch;
+  display: flex;
   flex: 1 1 50%;
   padding: 4px;
   text-decoration: none;


### PR DESCRIPTION
This PR does not close an issue.

## What does this PR do?

Ensures that home buttons stretch to fill the height of their current row.

### Before

<img width="300" alt="example of buttons not stretching" src="https://user-images.githubusercontent.com/6598084/66009612-7b753c80-e478-11e9-890e-dfd14a42658c.png">

### After

<img width="300" alt="example of buttons stretching" src="https://user-images.githubusercontent.com/6598084/66009626-8760fe80-e478-11e9-8f06-5e4290d7abc2.png">

## How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![thats a stretch](https://media.giphy.com/media/3ohhwedTLPDQgbPVLy/giphy.gif)
