### PR TITLE
add handling for a missing schedule on resource page

### DIFF
--- a/src/utils/getPreFilledLink/getScheduleUrlParams/index.ts
+++ b/src/utils/getPreFilledLink/getScheduleUrlParams/index.ts
@@ -36,7 +36,7 @@ const getScheduleTimesQuestionParams = (schedules: TSchedule[]) => {
 };
 
 const getScheduleQuestionUrlParams = ({ schedule: schedules }: TResource) => {
-  if (!schedules.length) {
+  if (!schedules || !schedules.length) {
     return '';
   }
 


### PR DESCRIPTION
This PR does not close an issue.

## What does this PR do?

Adds handling for missing schedules on the resource page. This will prevent the page from crashing on those resources.

## How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/6uGhT1O4sxpi8/giphy.gif)
