### PR TITLE
Add main menu #126

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1361,12 +1361,26 @@
       }
     },
     "@material-ui/icons": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-3.0.2.tgz",
-      "integrity": "sha512-QY/3gJnObZQ3O/e6WjH+0ah2M3MOgLOzCy8HTUoUx9B6dDrS18vP7Ycw3qrDEKlB6q1KNxy6CZHm5FCauWGy2g==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.5.1.tgz",
+      "integrity": "sha512-YZ/BgJbXX4a0gOuKWb30mBaHaoXRqPanlePam83JQPZ/y4kl+3aW0Wv9tlR70hB5EGAkEJGW5m4ktJwMgxQAeA==",
       "requires": {
-        "@babel/runtime": "^7.2.0",
-        "recompose": "0.28.0 - 0.30.0"
+        "@babel/runtime": "^7.4.4"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz",
+          "integrity": "sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+        }
       }
     },
     "@material-ui/lab": {
@@ -3940,11 +3954,6 @@
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
       }
-    },
-    "change-emitter": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
-      "integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
     },
     "chardet": {
       "version": "0.7.0",
@@ -7390,35 +7399,6 @@
       "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
       "requires": {
         "bser": "^2.0.0"
-      }
-    },
-    "fbjs": {
-      "version": "0.8.17",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-      "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.18"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-        },
-        "promise": {
-          "version": "7.3.1",
-          "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-          "requires": {
-            "asap": "~2.0.3"
-          }
-        }
       }
     },
     "figgy-pudding": {
@@ -16873,11 +16853,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.3.tgz",
       "integrity": "sha512-Y4rC1ZJmsxxkkPuMLwvKvlL1Zfpbcu+Bf4ZigkHup3v9EfdYhAlWAaVyA19olXq2o2mGn0w+dFKvk3pVVlYcIA=="
     },
-    "react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-    },
     "react-router": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.3.1.tgz",
@@ -17391,19 +17366,6 @@
       "integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
       "requires": {
         "util.promisify": "^1.0.0"
-      }
-    },
-    "recompose": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.30.0.tgz",
-      "integrity": "sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==",
-      "requires": {
-        "@babel/runtime": "^7.0.0",
-        "change-emitter": "^0.1.2",
-        "fbjs": "^0.8.1",
-        "hoist-non-react-statics": "^2.3.1",
-        "react-lifecycles-compat": "^3.0.2",
-        "symbol-observable": "^1.0.4"
       }
     },
     "recursive-readdir": {
@@ -19119,7 +19081,8 @@
     "symbol-observable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+      "dev": true
     },
     "symbol-tree": {
       "version": "3.2.2",
@@ -19495,11 +19458,6 @@
       "version": "3.3.4000",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.4000.tgz",
       "integrity": "sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA=="
-    },
-    "ua-parser-js": {
-      "version": "0.7.19",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
-      "integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
     },
     "uglify-js": {
       "version": "3.4.9",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.4.3",
-    "@material-ui/icons": "^3.0.2",
+    "@material-ui/icons": "^4.5.1",
     "@material-ui/lab": "^4.0.0-alpha.27",
     "@types/algoliasearch": "^3.30.12",
     "@types/enzyme": "^3.9.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import Hotlines from './components/Hotlines';
 import PrivacyPolicy from './components/PrivacyPolicy';
 import Resource from './components/Resource';
 import Search from './components/Search';
-import TermsOfService from './components/TermsOfService';
+import TermsOfUse from './components/TermsOfUse';
 
 const {
   Food,
@@ -45,7 +45,7 @@ class App extends Component {
             <Route exact path="/resources" component={Resources} />
             <Route exact path="/social-services" component={SocialServices} />
             <Route exact path="/search" component={Search} />
-            <Route exact path="/terms-of-service" component={TermsOfService} />
+            <Route exact path="/terms-of-use" component={TermsOfUse} />
             <Route exact path="/wifi" component={Wifi} />
           </div>
         </Router>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import Categories from './components/Categories';
 import Header from './components/Header';
 import Home from './components/Home';
 import Hotlines from './components/Hotlines';
+import PrivacyPolicy from './components/PrivacyPolicy';
 import Resource from './components/Resource';
 import Search from './components/Search';
 import TermsOfService from './components/TermsOfService';
@@ -38,6 +39,7 @@ class App extends Component {
             <Route exact path="/hygiene" component={Hygiene} />
             <Route exact path="/hotlines" component={Hotlines} />
             <Route exact path="/food" component={Food} />
+            <Route exact path="/privacy-policy" component={PrivacyPolicy} />
             <Route exact path="/transit" component={Transit} />
             <Route exact path="/resource" component={Resource} />
             <Route exact path="/resources" component={Resources} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,14 @@
 import React, { Component } from 'react';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
 import GlobalStyle from './App.styles';
+import About from './components/About';
 import Categories from './components/Categories';
 import Header from './components/Header';
 import Home from './components/Home';
 import Hotlines from './components/Hotlines';
 import Resource from './components/Resource';
 import Search from './components/Search';
+import TermsOfService from './components/TermsOfService';
 
 const {
   Food,
@@ -29,6 +31,7 @@ class App extends Component {
           <div>
             <Header />
             <Route exact path="/" component={Home} />
+            <Route exact path="/about" component={About} />
             <Route exact path="/shelters" component={Shelters} />
             <Route exact path="/job-training" component={JobTraining} />
             <Route exact path="/health" component={Health} />
@@ -40,6 +43,7 @@ class App extends Component {
             <Route exact path="/resources" component={Resources} />
             <Route exact path="/social-services" component={SocialServices} />
             <Route exact path="/search" component={Search} />
+            <Route exact path="/terms-of-service" component={TermsOfService} />
             <Route exact path="/wifi" component={Wifi} />
           </div>
         </Router>

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,11 +1,39 @@
 import React from 'react';
+import styled from 'styled-components';
 
-import { Container, colors } from '../App.styles';
+import { Container, colors, font } from '../App.styles';
+import Logo from './Logo';
 import PageBanner from './PageBanner';
+
+const StyledLogo = styled(Logo)`
+  display: block;
+  margin: ${font.helpers.convertPixelsToRems(30)} auto;
+`;
 
 const About = () => (
   <Container>
     <PageBanner color={colors.orangeDark} text={'About Upswyng'} />
+    <p>
+      Upswyng is a mobile app that can help people in need locate services where
+      they can find Food, Shelter, Health, Resources and Work.
+    </p>
+    <StyledLogo />
+    <p>
+      Upswyng is maintained by{' '}
+      <a href="http://www.codeforboulder.org" target="_blank" rel="noopener">
+        Code for Boulder
+      </a>
+      , part of{' '}
+      <a href="https://www.codeforamerica.org/" target="_blank" rel="noopener">
+        Code for America&apos;s
+      </a>{' '}
+      Brigade network.
+    </p>
+    <p>
+      For questions related to Upswyng or if you want to deploy it in your
+      community, please contact{' '}
+      <a href="mailto:info@upswyng.org">info@upswyng.org</a>.
+    </p>
   </Container>
 );
 

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -20,11 +20,19 @@ const About = () => (
     <StyledLogo />
     <p>
       Upswyng is maintained by{' '}
-      <a href="http://www.codeforboulder.org" target="_blank" rel="noopener">
+      <a
+        href="http://www.codeforboulder.org"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         Code for Boulder
       </a>
       , part of{' '}
-      <a href="https://www.codeforamerica.org/" target="_blank" rel="noopener">
+      <a
+        href="https://www.codeforamerica.org/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         Code for America&apos;s
       </a>{' '}
       Brigade network.

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import { Container, colors } from '../App.styles';
+import PageBanner from './PageBanner';
+
+const About = () => (
+  <Container>
+    <PageBanner color={colors.orangeDark} text={'About Upswyng'} />
+  </Container>
+);
+
+export default About;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
 import IconButton from '@material-ui/core/IconButton';
@@ -9,6 +9,7 @@ import styled from 'styled-components';
 
 import Logo from './Logo';
 import Temperature from './Temperature';
+import MenuDrawer from './MenuDrawer';
 import { Container, font } from '../App.styles';
 
 const headerVerticalMargin = 24;
@@ -38,12 +39,18 @@ const StyledLogo = styled(Logo)`
 ` as typeof Logo;
 
 const Header = () => {
+  const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false);
+
   return (
     <StyledHeader position="static">
       <Toolbar>
         <Container container justify="space-between" alignItems="center">
           <Grid item>
-            <StyledMenuButton color="inherit" aria-label="Menu">
+            <StyledMenuButton
+              color="inherit"
+              aria-label="Menu"
+              onClick={() => setIsMenuOpen(true)}
+            >
               <MenuIcon />
             </StyledMenuButton>
           </Grid>
@@ -59,6 +66,7 @@ const Header = () => {
           </Grid>
         </Container>
       </Toolbar>
+      <MenuDrawer open={isMenuOpen} onClose={() => setIsMenuOpen(false)} />
     </StyledHeader>
   );
 };

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -66,7 +66,10 @@ const Header = () => {
           </Grid>
         </Container>
       </Toolbar>
-      <MenuDrawer open={isMenuOpen} onClose={() => setIsMenuOpen(false)} />
+      <MenuDrawer
+        open={isMenuOpen}
+        handleMenuClose={() => setIsMenuOpen(false)}
+      />
     </StyledHeader>
   );
 };

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -13,6 +13,7 @@ import {
   NextWeek,
   People,
   Pets,
+  Policy,
   Wifi
 } from '@material-ui/icons';
 import { SvgIconProps } from '@material-ui/core/SvgIcon';
@@ -42,6 +43,7 @@ export const TermsOfServiceIcon: React.ReactElement<SvgIconProps> = (
 );
 export const PeopleIcon: React.ReactElement<SvgIconProps> = <People />;
 export const PetsIcon: React.ReactElement<SvgIconProps> = <Pets />;
+export const PolicyIcon: React.ReactElement<SvgIconProps> = <Policy />;
 export const SocksIcon: React.ReactElement<SvgIconProps> = <Socks />;
 export const WalkIcon: React.ReactElement<SvgIconProps> = <DirectionsWalk />;
 export const WifiIcon: React.ReactElement<SvgIconProps> = <Wifi />;

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -8,7 +8,9 @@ import {
   DirectionsCar,
   DirectionsWalk,
   Home,
+  Info,
   LocalHospital,
+  NextWeek,
   People,
   Pets,
   Wifi
@@ -31,8 +33,12 @@ export const CarIcon: React.ReactElement<SvgIconProps> = <DirectionsCar />;
 export const CloseIcon: React.ReactElement<SvgIconProps> = <Close />;
 export const HomeIcon: React.ReactElement<SvgIconProps> = <Home />;
 export const HygieneIcon: React.ReactElement<SvgIconProps> = <Hygiene />;
+export const InfoIcon: React.ReactElement<SvgIconProps> = <Info />;
 export const LocalHospitalIcon: React.ReactElement<SvgIconProps> = (
   <LocalHospital />
+);
+export const TermsOfServiceIcon: React.ReactElement<SvgIconProps> = (
+  <NextWeek />
 );
 export const PeopleIcon: React.ReactElement<SvgIconProps> = <People />;
 export const PetsIcon: React.ReactElement<SvgIconProps> = <Pets />;

--- a/src/components/MenuDrawer.tsx
+++ b/src/components/MenuDrawer.tsx
@@ -103,12 +103,9 @@ const MenuDrawer = ({ handleMenuClose, open }: MenuDrawerProps) => (
         </StyledMenuLink>
       </ListItem>
       <ListItem>
-        <StyledMenuLink
-          onClick={() => handleMenuClose()}
-          to="/terms-of-service"
-        >
+        <StyledMenuLink onClick={() => handleMenuClose()} to="/terms-of-use">
           <StyledListIcon>{TermsOfServiceIcon}</StyledListIcon>
-          Terms of Service
+          Terms of Use
         </StyledMenuLink>
       </ListItem>
       <ListItem>

--- a/src/components/MenuDrawer.tsx
+++ b/src/components/MenuDrawer.tsx
@@ -88,18 +88,25 @@ const MenuDrawer = ({ handleMenuClose, open }: MenuDrawerProps) => (
     </StyledDrawerHeader>
     <List>
       <ListItem>
-        <StyledMenuLink to="/" aria-label="home">
+        <StyledMenuLink
+          aria-label="home"
+          onClick={() => handleMenuClose()}
+          to="/"
+        >
           <StyledLogo />
         </StyledMenuLink>
       </ListItem>
       <ListItem>
-        <StyledMenuLink to="/about">
+        <StyledMenuLink onClick={() => handleMenuClose()} to="/about">
           <StyledListIcon>{InfoIcon}</StyledListIcon>
           About
         </StyledMenuLink>
       </ListItem>
       <ListItem>
-        <StyledMenuLink to="/terms-of-service">
+        <StyledMenuLink
+          onClick={() => handleMenuClose()}
+          to="/terms-of-service"
+        >
           <StyledListIcon>{TermsOfServiceIcon}</StyledListIcon>
           Terms of Service
         </StyledMenuLink>

--- a/src/components/MenuDrawer.tsx
+++ b/src/components/MenuDrawer.tsx
@@ -9,7 +9,7 @@ import { Link, NavLinkProps } from 'react-router-dom';
 import styled from 'styled-components';
 
 import Logo from './Logo';
-import { CloseIcon, InfoIcon, TermsOfServiceIcon } from './Icons';
+import { CloseIcon, InfoIcon, PolicyIcon, TermsOfServiceIcon } from './Icons';
 import { colors, font } from '../App.styles';
 
 const StyledDrawer = styled(Drawer)`
@@ -109,6 +109,12 @@ const MenuDrawer = ({ handleMenuClose, open }: MenuDrawerProps) => (
         >
           <StyledListIcon>{TermsOfServiceIcon}</StyledListIcon>
           Terms of Service
+        </StyledMenuLink>
+      </ListItem>
+      <ListItem>
+        <StyledMenuLink onClick={() => handleMenuClose()} to="/privacy-policy">
+          <StyledListIcon>{PolicyIcon}</StyledListIcon>
+          Privacy policy
         </StyledMenuLink>
       </ListItem>
     </List>

--- a/src/components/MenuDrawer.tsx
+++ b/src/components/MenuDrawer.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import Drawer, { DrawerProps } from '@material-ui/core/Drawer';
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+
+const MenuDrawer = (props: DrawerProps) => (
+  <Drawer {...props}>
+    <List>
+      <ListItem>Item 1</ListItem>
+      <ListItem>Item 2</ListItem>
+    </List>
+  </Drawer>
+);
+
+export default MenuDrawer;

--- a/src/components/MenuDrawer.tsx
+++ b/src/components/MenuDrawer.tsx
@@ -1,16 +1,111 @@
 import React from 'react';
 
 import Drawer, { DrawerProps } from '@material-ui/core/Drawer';
+import IconButton from '@material-ui/core/IconButton';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import { Link, NavLinkProps } from 'react-router-dom';
+import styled from 'styled-components';
 
-const MenuDrawer = (props: DrawerProps) => (
-  <Drawer {...props}>
+import Logo from './Logo';
+import { CloseIcon, InfoIcon, TermsOfServiceIcon } from './Icons';
+import { colors, font } from '../App.styles';
+
+const StyledDrawer = styled(Drawer)`
+  && {
+    .MuiPaper-root {
+      background: ${colors.charcoal};
+      font-size: ${font.helpers.convertPixelsToRems(24)};
+      max-width: 100%;
+      position: relative;
+      width: ${font.helpers.convertPixelsToRems(400)};
+    }
+  }
+` as typeof Drawer;
+
+const StyledDrawerHeader = styled.div`
+  display: block;
+  margin-bottom: ${font.helpers.convertPixelsToRems(15)};
+  position: relative;
+`;
+
+const StyledCloseButton = styled(IconButton)`
+  && {
+    color: ${colors.white};
+    position: absolute;
+    right: 0;
+    top: 0;
+    z-index: 10;
+  }
+` as typeof IconButton;
+
+const StyledMenuLink = styled((props: NavLinkProps) => {
+  const { children, ...rest } = props;
+  return <Link {...rest}>{children}</Link>;
+})`
+  && {
+    display: flex;
+    align-items: center;
+    &:link,
+    &:visited {
+      text-decoration: none;
+    }
+    &:hover,
+    &:active {
+      text-decoration: underline;
+    }
+  }
+`;
+
+const StyledListIcon = styled(ListItemIcon)`
+  && {
+    color: ${colors.white};
+  }
+` as typeof ListItemIcon;
+
+const StyledLogo = styled(Logo)`
+  && {
+    max-width: 100%;
+    width: ${font.helpers.convertPixelsToRems(250)};
+  }
+` as typeof Logo;
+
+interface MenuDrawerProps {
+  handleMenuClose: Function;
+  open: boolean;
+}
+
+const MenuDrawer = ({ handleMenuClose, open }: MenuDrawerProps) => (
+  <StyledDrawer onClose={() => handleMenuClose()} open={open}>
+    <StyledDrawerHeader>
+      <StyledCloseButton
+        aria-label="close menu"
+        onClick={() => handleMenuClose()}
+      >
+        {CloseIcon}
+      </StyledCloseButton>
+    </StyledDrawerHeader>
     <List>
-      <ListItem>Item 1</ListItem>
-      <ListItem>Item 2</ListItem>
+      <ListItem>
+        <StyledMenuLink to="/" aria-label="home">
+          <StyledLogo />
+        </StyledMenuLink>
+      </ListItem>
+      <ListItem>
+        <StyledMenuLink to="/about">
+          <StyledListIcon>{InfoIcon}</StyledListIcon>
+          About
+        </StyledMenuLink>
+      </ListItem>
+      <ListItem>
+        <StyledMenuLink to="/terms-of-service">
+          <StyledListIcon>{TermsOfServiceIcon}</StyledListIcon>
+          Terms of Service
+        </StyledMenuLink>
+      </ListItem>
     </List>
-  </Drawer>
+  </StyledDrawer>
 );
 
 export default MenuDrawer;

--- a/src/components/PrivacyPolicy.tsx
+++ b/src/components/PrivacyPolicy.tsx
@@ -44,7 +44,7 @@ const PrivacyPolicy = () => (
       <li>How you can correct any inaccuracies in your information.</li>
     </ol>
     <p>
-      Questions regarding this statement should be directed to the Strappd.org
+      Questions regarding this statement should be directed to the Upswyng.org
       by sending an email <a href="mailto:info@upswyng.org">info@upswyng.org</a>
       . Please reference this Privacy Policy in your subject line.
     </p>
@@ -84,7 +84,7 @@ const PrivacyPolicy = () => (
       emailing a photograph to the Site, you confirm that:
     </p>
     <ol>
-      <li>You are authorized to provide the photograph to Strappd.org;</li>
+      <li>You are authorized to provide the photograph to Upswyng.org;</li>
       <li>
         Any/all people appearing in the photograph have provided you with
         explicit approval to be photographed and for the photograph to be
@@ -95,12 +95,12 @@ const PrivacyPolicy = () => (
         <LowerAlphaList>
           <li>Having the photograph appear on the Site;</li>
           <li>
-            Allowing the photograph to be used by Strappd.org for informational
+            Allowing the photograph to be used by Upswyng.org for informational
             or educational purposes which may include appearing in mass media,
             video, presentations, printed material or emails on our Site;
           </li>
           <li>
-            The use of the photograph by Strappd.org for informational,
+            The use of the photograph by Upswyng.org for informational,
             educational or promotional purposes does not entitle you or anyone
             else to any prior notice, compensation or other remedies; and
           </li>
@@ -112,10 +112,10 @@ const PrivacyPolicy = () => (
       </li>
     </ol>
     <p>
-      Strappd.org will not publish or otherwise distribute your name or other
+      Upswyng.org will not publish or otherwise distribute your name or other
       personally identifying information (or that of others appearing in the
       textual, image or video) without your prior explicit consent. Instead,
-      Strappd.org may elect to use your initials and city/state if needed. We do
+      Upswyng.org may elect to use your initials and city/state if needed. We do
       not collect or store sensitive information such as credit card or social
       security numbers.
     </p>
@@ -134,11 +134,11 @@ const PrivacyPolicy = () => (
       action regarding illegal activities, suspected fraud, situations involving
       potential threats to the physical safety of any person, violations of our
       Terms of Use, or as otherwise required by law. Agents and contractors of
-      Strappd.org who have access to personally identifiable information are
+      Upswyng.org who have access to personally identifiable information are
       required to protect this information in a manner that is consistent with
       this Privacy Policy by, for example, not using the information for any
       purpose other than to carry out the services they are performing for
-      Strappd.org. Although we take appropriate measures to safeguard against
+      Upswyng.org. Although we take appropriate measures to safeguard against
       unauthorized disclosures of information, we cannot assure you that
       personally identifiable information that we collect will never be
       disclosed in a manner that is inconsistent with this Privacy Policy.
@@ -153,14 +153,14 @@ const PrivacyPolicy = () => (
     <p>
       Our Site contains links to other web sites. Please note that when you
       click on one of these links, you are entering another web site for which
-      Strappd.org has no responsibility. We encourage you to read the privacy
+      Upswyng.org has no responsibility. We encourage you to read the privacy
       statements on all such sites as their policies may be different than ours.
       We have no control over information that is submitted to, or collected by,
       these third parties.
     </p>
     <h2>Children’s Online Privacy Protection</h2>
     <p>
-      Strappd.org is not intended for children under 13 years of age. No one
+      Upswyng.org is not intended for children under 13 years of age. No one
       under the age 13 may provide any personal information to the Website or
       application. We do not knowingly collect personal information from
       children under 13. If you are under 13, do not use or provide any
@@ -184,7 +184,7 @@ const PrivacyPolicy = () => (
     <h2>Contacting the Web Site:</h2>
     <p>
       If you have any questions about this Privacy Policy, the practices of this
-      Site, or your dealings with this Site, you can contact:
+      Site, or your dealings with this Site, you can contact:{' '}
       <a href="mailto:info@upswyng.org">info@upswyng.org</a>.
     </p>
   </Container>

--- a/src/components/PrivacyPolicy.tsx
+++ b/src/components/PrivacyPolicy.tsx
@@ -1,0 +1,193 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Link } from 'react-router-dom';
+
+import { Container, colors } from '../App.styles';
+import PageBanner from './PageBanner';
+
+const LowerAlphaList = styled.ol`
+  list-style-type: lower-alpha;
+`;
+
+const PrivacyPolicy = () => (
+  <Container>
+    <PageBanner color={colors.orangeDark} text={'Privacy Policy'} />
+    <p>
+      Upswyng has created this Privacy Policy to explain why we collect
+      particular information and how we will protect your personal privacy
+      within our Web site. This Privacy Policy discloses our information
+      gathering and dissemination practices for the Web site located at the URL{' '}
+      <Link to="/">https://upswyng.org</Link> (the “Site”).
+    </p>
+    <p>
+      In order to fully understand your rights we encourage you to read this
+      Privacy Policy as well as our{' '}
+      <Link to="/terms-of-service">Terms of Use</Link>. This Privacy Policy is
+      incorporated by reference into and is subject to our{' '}
+      <Link to="/terms-of-service">Terms of Use</Link>. upswyng.org reserves the
+      right at any time and without notice to change this Privacy Policy simply
+      by posting such changes on our Site. Any such change will be effective
+      immediately upon posting.
+    </p>
+    <p>
+      Because we want to demonstrate our commitment to your privacy, this
+      Privacy Policy notifies you of:
+    </p>
+    <ol>
+      <li>
+        What personally identifiable information of yours is collected through
+        the Site;
+      </li>
+      <li>Who collects such information;</li>
+      <li>How such information is used;</li>
+      <li>With whom your information may be shared; and</li>
+      <li>How you can correct any inaccuracies in your information.</li>
+    </ol>
+    <p>
+      Questions regarding this statement should be directed to the Strappd.org
+      by sending an email <a href="mailto:info@upswyng.org">info@upswyng.org</a>
+      . Please reference this Privacy Policy in your subject line.
+    </p>
+    <h2>What Information We Collect and How We Use That Information</h2>
+    <p>
+      When you download, register with, or use upswyng.org or its mobile
+      application version we may ask you to provide information:
+    </p>
+    <ol>
+      <li>
+        By which you may be personally identified, such as name, postal address
+        if applicable, email address, telephone number, or age (“personal
+        information”);
+      </li>
+      <li>
+        Information that you provide by filling in forms in the App or Website;
+      </li>
+      <li>
+        Records and copies of your correspondence with service providers or the
+        us;
+      </li>
+      <li>Your search queries on the App or Website;</li>
+      <li>
+        Real-time information about the location of your device (collectively
+        “User Contributions”).
+      </li>
+    </ol>
+    <p>
+      Your User Contributions are transmitted at your own risk. Please be aware
+      that no security measures are perfect or impenetrable. Additionally, we
+      cannot control the actions of third parties with whom you may choose to
+      share your User Contributions. Therefore, we cannot and do not guarantee
+      that your User Contributions will not be viewed by unauthorized persons.
+    </p>
+    <p>
+      You may also optionally upload a photograph of yourself. By uploading or
+      emailing a photograph to the Site, you confirm that:
+    </p>
+    <ol>
+      <li>You are authorized to provide the photograph to Strappd.org;</li>
+      <li>
+        Any/all people appearing in the photograph have provided you with
+        explicit approval to be photographed and for the photograph to be
+        uploaded to the Site; and
+      </li>
+      <li>
+        You and anyone appearing the photograph explicitly agree to:
+        <LowerAlphaList>
+          <li>Having the photograph appear on the Site;</li>
+          <li>
+            Allowing the photograph to be used by Strappd.org for informational
+            or educational purposes which may include appearing in mass media,
+            video, presentations, printed material or emails on our Site;
+          </li>
+          <li>
+            The use of the photograph by Strappd.org for informational,
+            educational or promotional purposes does not entitle you or anyone
+            else to any prior notice, compensation or other remedies; and
+          </li>
+          <li>
+            Not have any personally identifying information (such as a name of
+            an individual) appear in the photograph.
+          </li>
+        </LowerAlphaList>
+      </li>
+    </ol>
+    <p>
+      Strappd.org will not publish or otherwise distribute your name or other
+      personally identifying information (or that of others appearing in the
+      textual, image or video) without your prior explicit consent. Instead,
+      Strappd.org may elect to use your initials and city/state if needed. We do
+      not collect or store sensitive information such as credit card or social
+      security numbers.
+    </p>
+    <h2>Use of “Cookies”</h2>
+    <p>
+      Cookies are pieces of information that some web sites transfer to the
+      computer that is browsing that web site and are used for record-keeping
+      purposes at many web sites. Upswyng does not use cookies.
+    </p>
+    <h2>Disclosure</h2>
+    <p>
+      We may disclose personally identifiable information in response to legal
+      process for example, in response to a court order or a subpoena. We also
+      may disclose such information in response to a law enforcement agency’s
+      request or where we believe it necessary to investigate, prevent or take
+      action regarding illegal activities, suspected fraud, situations involving
+      potential threats to the physical safety of any person, violations of our
+      Terms of Use, or as otherwise required by law. Agents and contractors of
+      Strappd.org who have access to personally identifiable information are
+      required to protect this information in a manner that is consistent with
+      this Privacy Policy by, for example, not using the information for any
+      purpose other than to carry out the services they are performing for
+      Strappd.org. Although we take appropriate measures to safeguard against
+      unauthorized disclosures of information, we cannot assure you that
+      personally identifiable information that we collect will never be
+      disclosed in a manner that is inconsistent with this Privacy Policy.
+    </p>
+    <h2>Correcting Information</h2>
+    <p>
+      Upon request, we will provide you with access to the information we
+      maintain about you, including contact information. You may correct and
+      update this information by providing us with the correct information.
+    </p>
+    <h2>Other Web Sites</h2>
+    <p>
+      Our Site contains links to other web sites. Please note that when you
+      click on one of these links, you are entering another web site for which
+      Strappd.org has no responsibility. We encourage you to read the privacy
+      statements on all such sites as their policies may be different than ours.
+      We have no control over information that is submitted to, or collected by,
+      these third parties.
+    </p>
+    <h2>Children’s Online Privacy Protection</h2>
+    <p>
+      Strappd.org is not intended for children under 13 years of age. No one
+      under the age 13 may provide any personal information to the Website or
+      application. We do not knowingly collect personal information from
+      children under 13. If you are under 13, do not use or provide any
+      information on this Website or application. If we learn we have collected
+      or received personal information from a child under 13 without
+      verification of parental consent, we will delete that information. If you
+      believe we might have any information from or about a child under 13,
+      please contact us at{' '}
+      <a href="mailto:info@upswyng.org">info@upswyng.org</a>.
+    </p>
+    <h2>Consent; Changes to Privacy Policy</h2>
+    <p>
+      By using the Site, you consent to the collection, use, and storage of your
+      information by us in the manner described in this Privacy Policy and
+      elsewhere on the Site. We reserve the right to make changes to this
+      Privacy Policy from time to time. We will alert you to any material
+      changes by sending a notice to the e-mail address you provided to us or
+      updating this Privacy Policy. This Privacy Policy was last updated on July
+      11, 2018.
+    </p>
+    <h2>Contacting the Web Site:</h2>
+    <p>
+      If you have any questions about this Privacy Policy, the practices of this
+      Site, or your dealings with this Site, you can contact:
+      <a href="mailto:info@upswyng.org">info@upswyng.org</a>.
+    </p>
+  </Container>
+);
+
+export default PrivacyPolicy;

--- a/src/components/PrivacyPolicy.tsx
+++ b/src/components/PrivacyPolicy.tsx
@@ -21,10 +21,9 @@ const PrivacyPolicy = () => (
     </p>
     <p>
       In order to fully understand your rights we encourage you to read this
-      Privacy Policy as well as our{' '}
-      <Link to="/terms-of-service">Terms of Use</Link>. This Privacy Policy is
-      incorporated by reference into and is subject to our{' '}
-      <Link to="/terms-of-service">Terms of Use</Link>. upswyng.org reserves the
+      Privacy Policy as well as our <Link to="/terms-of-use">Terms of Use</Link>
+      . This Privacy Policy is incorporated by reference into and is subject to
+      our <Link to="/terms-of-use">Terms of Use</Link>. upswyng.org reserves the
       right at any time and without notice to change this Privacy Policy simply
       by posting such changes on our Site. Any such change will be effective
       immediately upon posting.

--- a/src/components/TermsOfService.tsx
+++ b/src/components/TermsOfService.tsx
@@ -6,6 +6,135 @@ import PageBanner from './PageBanner';
 const TermsOfService = () => (
   <Container>
     <PageBanner color={colors.orangeDark} text={'Terms of Service'} />
+    <p>
+      Upswyng provides its content on this website (the “Site”) and mobile
+      applications (the “App”) which enable users to locate resources including
+      food banks, medical centers, and shelters (the “Services”) subject to the
+      following terms and conditions (the “Terms”). Upswyng may amend the Terms
+      from time to time. Amendments will be effective upon Upswyng’s posting of
+      such updated Terms at this location. Your continued use of the Services
+      after such posting confirms your consent to be bound by the Terms, as
+      amended.
+    </p>
+    <h2>1. The Services</h2>
+    <h3>License.</h3>
+    <p>
+      Subject to compliance with these Terms, Upswyng grants you a limited,
+      non-exclusive, nonsublicensable, revocable, non-transferable license to:
+      (i) access and use the Site, or the App on your personal device solely in
+      connection with your use of the Services; and (ii) access and use any
+      content, information, and related information that may be made available
+      through the Services, in each case solely for your personal, noncommercial
+      use. Any rights not expressely granted herein are reserved Upswyng.
+    </p>
+    <h3>Restrictions.</h3>
+    <p>
+      You may not: (i) remove any copyright, trademark or other proprietary
+      notices from any portion of the Services; (ii) reproduce, modify, prepare
+      derivative works based upon, distribute, license, lease, sell, resell,
+      transfer, publicly display, publicly perform, transmit, stream, broadcast
+      or otherwise exploit the Services except as expressly permitted by
+      Upswyng; (iii) decompile, reverse engineer or disassemble the Services
+      except as may be permitted by applicable law; (iv) link to, mirror or
+      frame any portion of the Services; (v) cause or launch any programs or
+      scripts for the purpose of scraping, indexing, surveying, or otherwise
+      data mining any portion of the Services or unduly burdening or hindering
+      the operation and/or functionality of any aspect of the Services; or (vi)
+      attempt to gain unauthorized access to or impair any aspect of the
+      Services or its related systems or networks.
+    </p>
+    <h3>Ownership.</h3>
+    <p>
+      The Services and all rights therein are and shall remain Upswyng&apos;s
+      property or the property of Upswyng&apos;s licensors. Neither these Terms
+      nor your use of the Services convey or grant to you any rights: (i) in or
+      related to the Services except for the limited license granted above; or
+      (ii) to use or reference in any manner Upswyng&apos;s company names,
+      logos, product and service names, trademarks or services marks or those of
+      Upswyng&apos;s licensors.
+    </p>
+    <h3>Copyrights.</h3>
+    <p>
+      All content and functionality on the Site, including text, graphics,
+      logos, icons, and images and the selection and arrangement thereof is the
+      exclusive property of Upswyng or its licensors and is protected by U.S.
+      copyright laws. All rights not expressly granted are reserved.
+    </p>
+    <h2>2. Disclaimers; Limitation of Liability; Indemnity</h2>
+    <h3>DISCLAIMER.</h3>
+    <p>
+      THE SERVICES ARE PROVIDED &ldquo;AS IS&rdquo; AND &ldquo;AS
+      AVAILABLE.&rdquo; UPSWYNG DISCLAIMS ALL REPRESENTATIONS AND WARRANTIES,
+      EXPRESS, IMPLIED, OR STATUTORY, NOT EXPRESSLY SET OUT IN THESE TERMS,
+      INCLUDING THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+      PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN ADDITION, UPSWYNG MAKES NO
+      REPRESENTATION, WARRANTY, OR GUARANTEE REGARDING THE RELIABILITY,
+      TIMELINESS, QUALITY, SUITABILITY, OR AVAILABILITY OF THE SERVICES OR ANY
+      SERVICES OR GOODS REQUESTED THROUGH THE USE OF THE SERVICES, OR THAT THE
+      SERVICES WILL BE UNINTERRUPTED OR ERROR-FREE. UPSWYNG DOES NOT GUARANTEE
+      THE QUALITY, SUITABILITY, SAFETY OR ABILITY OF THIRD PARTY PROVIDERS. YOU
+      AGREE THAT THE ENTIRE RISK ARISING OUT OF YOUR USE OF THE SERVICES, AND
+      ANY SERVICE OR GOOD REQUESTED IN CONNECTION THEREWITH, REMAINS SOLELY WITH
+      YOU, TO THE MAXIMUM EXTENT PERMITTED UNDER APPLICABLE LAW.
+    </p>
+    <h3>LIMITATION OF LIABILITY.</h3>
+    <p>
+      UPSWYNG SHALL NOT BE LIABLE FOR INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+      PUNITIVE, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, LOST DATA,
+      PERSONAL INJURY, OR PROPERTY DAMAGE RELATED TO, IN CONNECTION WITH, OR
+      OTHERWISE RESULTING FROM ANY USE OF THE SERVICES, REGARDLESS OF THE
+      NEGLIGENCE (EITHER ACTIVE, AFFIRMATIVE, SOLE, OR CONCURRENT) OF UPSWYNG,
+      EVEN IF UPSWYNG HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. USE
+      OF THE UPSWYNG SITE, APP, OR ANY INFROMATION CONTAINED ON IT IS AT YOUR
+      OWN RISK.
+    </p>
+    <p>
+      UPSWYNG SHALL NOT BE LIABLE FOR ANY DAMAGES, LIABILITY OR LOSSES ARISING
+      OUT OF YOUR USE OF OR RELIANCE ON THE SERVICES OR YOUR INABILITY TO ACCESS
+      OR USE THE SERVICES. UPSWYNG SHALL NOT BE LIABLE FOR DELAY OR FAILURE IN
+      PERFORMANCE RESULTING FROM CAUSES BEYOND UPSWYNG&apos;s REASONABLE
+      CONTROL.
+    </p>
+    <p>
+      THE SERVICES MAY BE USED BY YOU TO REQUEST AND LOCATE SERVICES OUTLINED
+      ABOVE WITH THIRD PARTY PROVIDERS, BUT YOU AGREE THAT UPSWYNG HAS NO
+      RESPONSIBILITY OR LIABILITY TO YOU RELATED TO ANY OF THE SERVICES PROVIDED
+      TO YOU BY THIRD PARTY PROVIDERS OTHER THAN AS EXPRESSLY SET FORTH IN THESE
+      TERMS.
+    </p>
+    <p>
+      THE LIMITATIONS AND DISCLAIMER IN THIS SECTION DO NOT PURPORT TO LIMIT
+      LIABILITY OR ALTER YOUR RIGHTS AS A CONSUMER THAT CANNOT BE EXCLUDED UNDER
+      APPLICABLE LAW. BECAUSE SOME STATES ORJURISDICTIONS DO NOT ALLOW THE
+      EXCLUSION OF OR THE LIMITATION OF LIABILITY FOR CONSEQUENTIAL OR
+      INCIDENTAL DAMAGES, IN SUCH STATES OR JURISDICTIONS, UPSWYNG’S LIABILITY
+      SHALL BE LIMITED TO THE EXTENT PERMITTED BY LAW. THIS PROVISION SHALL HAVE
+      NO EFFECT ON UPSWYNG’S CHOICE OF LAW PROVISION SET FORTH BELOW.
+    </p>
+    <h3>Indemnity.</h3>
+    <p>
+      You agree to indemnify and hold Upswyng and its affiliates and their
+      officers, directors, employees, and agents harmless from any and all
+      claims, demands, losses, liabilities, and expenses (including
+      attorneys&apos; fees), arising out of or in connection with: (i) your use
+      of the Services or services or goods obtained through your use of the
+      Services; or (ii) your breach or violation of any of these Terms.
+    </p>
+    <h2>3. General</h2>
+    <h3>Privacy Policy</h3>
+    <p>
+      In accordance with the terms of upswyng.org&apos;s Privacy Policy, Upswyng
+      respect&apos;s the privacy of its Users. Upswyng recommends users read its
+      Privacy Policy, available in the main menu, before using the website or
+      app.
+    </p>
+    <h3>Governing Law; Jurisdiction.</h3>
+    <p>
+      These Terms are governed by the laws of the State of Colorado without
+      reference to the principles of conflicts of laws thereof. Any dispute
+      arising from these Terms shall be resolved exclusively in the state and
+      federal courts of Colorado.
+    </p>
   </Container>
 );
 

--- a/src/components/TermsOfService.tsx
+++ b/src/components/TermsOfService.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import { Container, colors } from '../App.styles';
+import PageBanner from './PageBanner';
+
+const TermsOfService = () => (
+  <Container>
+    <PageBanner color={colors.orangeDark} text={'Terms of Service'} />
+  </Container>
+);
+
+export default TermsOfService;

--- a/src/components/TermsOfUse.tsx
+++ b/src/components/TermsOfUse.tsx
@@ -3,9 +3,9 @@ import React from 'react';
 import { Container, colors } from '../App.styles';
 import PageBanner from './PageBanner';
 
-const TermsOfService = () => (
+const TermsOfUse = () => (
   <Container>
-    <PageBanner color={colors.orangeDark} text={'Terms of Service'} />
+    <PageBanner color={colors.orangeDark} text={'Terms of Use'} />
     <p>
       Upswyng provides its content on this website (the “Site”) and mobile
       applications (the “App”) which enable users to locate resources including
@@ -138,4 +138,4 @@ const TermsOfService = () => (
   </Container>
 );
 
-export default TermsOfService;
+export default TermsOfUse;


### PR DESCRIPTION
This PR closes #126 .

## What does this PR do?

- adds a main menu that opens on the hamburger button found in the header
- adds "About", "Terms of Use", and "Privacy Policy" pages
- updates `@material-ui/icons` to the latest version

<img width="472" alt="example of open menu" src="https://user-images.githubusercontent.com/6598084/66889160-a2fef580-ef9e-11e9-9dad-795adba753ee.png">

## How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/vLFuPWk93HwnS/giphy.gif)
