### PR TITLE
🚑 Fix all kinds of resource errors

### DIFF
--- a/packages/upswyng-server/src/data-pipeline/updateAlgolia.ts
+++ b/packages/upswyng-server/src/data-pipeline/updateAlgolia.ts
@@ -1,7 +1,7 @@
 import * as dotenv from "dotenv";
 import algoliaSearch from "algoliasearch";
 import mongoose from "mongoose";
-import Resource from "../models/Resource";
+import Resource, { resourceDocumentToResource } from "../models/Resource";
 
 dotenv.config();
 
@@ -39,6 +39,7 @@ mongoose
       )
   )
   .then(() => Resource.getAll())
+  .then(resourceDocuments => resourceDocuments.map(resourceDocumentToResource))
   .then(resources => {
     const updatedAlgoliaIndex = resources.map(
       ({ id, name, description, subcategories }) => ({

--- a/packages/upswyng-server/src/models/Resource.ts
+++ b/packages/upswyng-server/src/models/Resource.ts
@@ -251,9 +251,15 @@ const legacyResourceToResource = (
 export const resourceToSchema = (r: Partial<TResource>) => {
   const result = {
     ...r,
-    id: ObjectId.createFromHexString(r.id),
-    _id: ObjectId.createFromHexString(r._id),
+    id: r.id ? ObjectId.createFromHexString(r.id) : undefined,
+    _id: r._id ? ObjectId.createFromHexString(r._id) : undefined,
   };
+  if (!r.id) {
+    delete result.id;
+  }
+  if (!r._id) {
+    delete result._id;
+  }
   delete result.latitude;
   delete result.longitude;
   return r.longitude && r.latitude
@@ -293,7 +299,7 @@ ResourceSchema.statics.addOrUpdateLegacyResource = async function(
     existingRecord.set(
       resourceToSchema(legacyResourceToResource(resource, new Date(), id))
     );
-    await existingRecord.save().then(resourceDocumentToResource);
+    await existingRecord.save();
   }
 };
 
@@ -378,11 +384,11 @@ export default Resource as typeof Resource & {
   addOrUpdateLegacyResource: (
     id: string,
     resource: TLegacyResource
-  ) => Promise<TResource>;
-  getAll: () => Promise<TResource[]>;
-  getById: (id: ObjectId) => Promise<TResource | null>;
-  getByRecordId: (id: ObjectId) => Promise<TResource | null>;
-  getUncategorized: () => Promise<TResource[]>;
+  ) => Promise<void>;
+  getAll: () => Promise<TResourceDocument[]>;
+  getById: (id: ObjectId) => Promise<TResourceDocument | null>;
+  getByRecordId: (id: ObjectId) => Promise<TResourceDocument | null>;
+  getUncategorized: () => Promise<TResourceDocument[]>;
 };
 
 const DraftResource = mongoose.model<TResourceDocument>(

--- a/packages/upswyng-server/src/routes/api/resource/[id].ts
+++ b/packages/upswyng-server/src/routes/api/resource/[id].ts
@@ -1,12 +1,20 @@
-import Resource from "../../../models/Resource";
+import Resource, {
+  resourceDocumentToResource,
+  TResourceDocument,
+} from "../../../models/Resource";
 import { ObjectId } from "bson";
 import { isAdmin } from "../../../utility/authHelpers";
+import { TResource } from "@upswyng/upswyng-types";
 
 export async function get(req, res, _next) {
   const { id } = req.params;
-  let resource = null;
+  let resourceDocument: TResourceDocument;
+  let resource: TResource;
   try {
-    resource = await Resource.getById(ObjectId.createFromHexString(id));
+    resourceDocument = await Resource.getById(ObjectId.createFromHexString(id));
+    if (resourceDocument) {
+      resource = resourceDocumentToResource(resourceDocument);
+    }
   } catch (e) {
     res.writeHead(500, {
       "Content-Type": "application/json",

--- a/packages/upswyng-server/src/routes/api/resource/draft/[id].ts
+++ b/packages/upswyng-server/src/routes/api/resource/draft/[id].ts
@@ -1,14 +1,23 @@
-import { DraftResource } from "../../../../models/Resource";
+import {
+  DraftResource,
+  TResourceDocument,
+  resourceDocumentToResource,
+} from "../../../../models/Resource";
 import { ObjectId } from "bson";
 import { isAdmin } from "../../../../utility/authHelpers";
+import { TResource } from "@upswyng/upswyng-types";
 
 export async function get(req, res, _next) {
   const { id } = req.params;
-  let draftResource = null;
+  let draftResourceDocument: TResourceDocument;
+  let draftResource: TResource;
   try {
-    draftResource = await DraftResource.getByRecordId(
+    draftResourceDocument = await DraftResource.getByRecordId(
       ObjectId.createFromHexString(id)
     );
+    if (draftResourceDocument) {
+      draftResource = resourceDocumentToResource(draftResourceDocument);
+    }
   } catch (e) {
     res.writeHead(500, {
       "Content-Type": "application/json",

--- a/packages/upswyng-server/src/routes/api/resource/draft/approve/[id].ts
+++ b/packages/upswyng-server/src/routes/api/resource/draft/approve/[id].ts
@@ -1,13 +1,14 @@
+import { createOrUpdateResourceFromDraft } from "../../../../../models/Utility";
 import {
   DraftResource,
   TResourceDocument,
   resourceDocumentToResource,
 } from "../../../../../models/Resource";
-import { createOrUpdateResourceFromDraft } from "../../../../../models/Utility";
+import { ObjectId } from "bson";
 import { requireAdmin } from "../../../../../utility/authHelpers";
 
 export async function post(req, res, next) {
-  const { id: resourceId } = req.params; // _id of resource to be approved
+  const { id: recordId }: { id: string } = req.params; // _id of resource to be approved
   try {
     requireAdmin(req);
   } catch (_e) {
@@ -25,7 +26,9 @@ export async function post(req, res, next) {
 
   let draftToApprove: TResourceDocument | null = null;
   try {
-    draftToApprove = await DraftResource.getByRecordId(resourceId);
+    draftToApprove = await DraftResource.getByRecordId(
+      ObjectId.createFromHexString(recordId)
+    );
 
     if (!draftToApprove) {
       res.writeHead(404, {
@@ -61,6 +64,7 @@ export async function post(req, res, next) {
 
     return res.end(JSON.stringify({ resource: updateResource }));
   } catch (e) {
+    console.error(e);
     res.writeHead(500, {
       "Content-Type": "application/json",
     });

--- a/packages/upswyng-server/src/routes/api/resource/draft/delete/[id].ts
+++ b/packages/upswyng-server/src/routes/api/resource/draft/delete/[id].ts
@@ -1,5 +1,9 @@
-import { DraftResource } from "../../../../../models/Resource";
+import {
+  DraftResource,
+  TResourceDocument,
+} from "../../../../../models/Resource";
 import { requireAdmin } from "../../../../../utility/authHelpers";
+import { ObjectId } from "bson";
 
 export async function post(req, res, next) {
   try {
@@ -18,9 +22,11 @@ export async function post(req, res, next) {
   }
 
   const { id } = req.params;
-  let deletedResource = null;
+  let deletedResource: TResourceDocument | null = null;
   try {
-    deletedResource = await DraftResource.deleteByRecordId(id);
+    deletedResource = await DraftResource.deleteByRecordId(
+      ObjectId.createFromHexString(id)
+    );
   } catch (e) {
     res.writeHead(500, {
       "Content-Type": "application/json",

--- a/packages/upswyng-server/src/routes/api/resource/index.ts
+++ b/packages/upswyng-server/src/routes/api/resource/index.ts
@@ -1,17 +1,6 @@
 import { createDraftResource } from "../../../models/Utility";
-import { ObjectId } from "bson";
 import { requireLoggedIn } from "../../../utility/authHelpers";
 import { TUser } from "@upswyng/upswyng-types";
-
-function createObjectIds(resource) {
-  Object.entries(resource).forEach(([k, v]) => {
-    if (k === "id" || k === "_id") {
-      resource[k] = ObjectId.createFromHexString(v as string);
-    } else if (typeof v === "object") {
-      createObjectIds(v);
-    }
-  });
-}
 
 /**
  * Creates a new draft resource. Resources and updates to resources
@@ -37,7 +26,7 @@ export async function post(req, res, next) {
   try {
     const { draftResource } = req.body;
     draftResource.createdBy = (user as TUser).id;
-    createObjectIds(draftResource);
+
     try {
       const newResource = await createDraftResource(draftResource);
       res.writeHead(201, { "Content-Type": "application/json" });

--- a/packages/upswyng-server/src/routes/api/subcategory/add-resource.ts
+++ b/packages/upswyng-server/src/routes/api/subcategory/add-resource.ts
@@ -57,7 +57,7 @@ export async function post(req, res, next) {
       throw new Error(`Could not find resource with IDDD ${resourceId}`);
     }
     await addResourceToSubcategory(
-      ObjectId.createFromHexString(resource._id),
+      resource._id,
       ObjectId.createFromHexString(subcategoryId)
     );
     res.writeHead(200, {

--- a/packages/upswyng-server/src/routes/resource/[id].svelte
+++ b/packages/upswyng-server/src/routes/resource/[id].svelte
@@ -91,7 +91,7 @@
         on:dispatchSaveResource={e => handleSaveClick(e.detail)} />
     {:else}
       <ResourceDisplay {resource} />
-      <p>Log in to make changes to this resource</p>
+      <div class="notification">Log in to make changes to this resource</div>
     {/if}
   </div>
 </section>

--- a/packages/upswyng-server/src/routes/resource/draft/[id].svelte
+++ b/packages/upswyng-server/src/routes/resource/draft/[id].svelte
@@ -77,6 +77,8 @@
   }
 
   function approveUpdate(id) {
+    isApproving = true;
+
     fetch(`/api/resource/draft/approve/${id}`, { method: "POST" })
       .then(_res => {
         if (_res.status >= 400) {
@@ -90,7 +92,7 @@
         goto("/resource");
       })
       .catch(e => (approveError = e))
-      .finally(() => (isDeleting = false));
+      .finally(() => (isApproving = false));
   }
 </script>
 


### PR DESCRIPTION
After refactoring the types between `TResourceDocument` and `TResource`, a bunch of stuff broke. Fix it.
- Fix drafts of resources not being saved due to `ObjectId` problems
- Fix drafts of resources not being approved due to a bug in `resourceToSchema` where either `id` or `_id` may have not been populated
- Fix types on interface of `Resource` model which had already been updated on `DraftResource` model
- Fixes `TResourceDocument` not being converted to `TResource` before being sent over the wire, which was causing the map not to show on the web client