### PR TITLE
🐛 Ignore node_modules in server jest config

### DIFF
--- a/packages/upswyng-server/jest.config.js
+++ b/packages/upswyng-server/jest.config.js
@@ -3,4 +3,5 @@ module.exports = {
   transform: {
     "^.+\\.tsx?$": "ts-jest",
   },
+  modulePathIgnorePatterns: ["node_modules"],
 };


### PR DESCRIPTION
I was getting an error when VSCode started: 'Starting Jest in Watch mode failed too many times and has been stopped'. This issue (https://github.com/facebook/jest/issues/3254) suggests ignoring node_modules, so I will try that.