### PR TITLE
🐛 Don't allow issues pagination step below 1

### DIFF
--- a/packages/upswyng-server/src/routes/resource/issues/index.svelte
+++ b/packages/upswyng-server/src/routes/resource/issues/index.svelte
@@ -227,7 +227,7 @@
 
 <section class="section">
   <div class="container">
-    <h1 class="title">Resource Issues{paginationStep}</h1>
+    <h1 class="title">Resource Issues</h1>
     {#if errorMessage}
       <div class="notification is-danger">
         <button

--- a/packages/upswyng-server/src/routes/resource/issues/index.svelte
+++ b/packages/upswyng-server/src/routes/resource/issues/index.svelte
@@ -97,7 +97,10 @@
   $: offset = (paginationStep - 1) * limit;
   $: {
     totalPaginationSteps = Math.ceil(count / limit);
-    paginationStep = Math.min(paginationStep, totalPaginationSteps);
+    paginationStep = Math.max(
+      Math.min(paginationStep, totalPaginationSteps),
+      1
+    );
   }
   $: {
     if (totalPaginationSteps <= 5) {
@@ -224,7 +227,7 @@
 
 <section class="section">
   <div class="container">
-    <h1 class="title">Resource Issues</h1>
+    <h1 class="title">Resource Issues{paginationStep}</h1>
     {#if errorMessage}
       <div class="notification is-danger">
         <button


### PR DESCRIPTION
When fetched count was below 1, page failed because pagination step would be set to 0 which caused the skip value to be negative.