### PR TITLE
🐛 Fix errors with Event Log diffs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,8 @@
     { "language": "typescriptreact", "autoFix": true }
   ],
   "eslint.enable": true,
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  }
 }

--- a/packages/upswyng-server/src/components/ResourceScheduleDisplay.svelte
+++ b/packages/upswyng-server/src/components/ResourceScheduleDisplay.svelte
@@ -2,7 +2,13 @@
   import ScheduleSelectorScheduleItem from "./ScheduleSelectorScheduleItem.svelte";
   import { ResourceSchedule } from "@upswyng/upswyng-core";
 
-  export let schedule; /* TResourceScheduleData */
+  export let schedule; /* TResourceScheduleData | ResourceSchedule */
+
+  $: {
+    if (!(schedule instanceof ResourceSchedule)) {
+      schedule = ResourceSchedule.parse(schedule);
+    }
+  }
 </script>
 
 <div class="content">

--- a/packages/upswyng-server/src/models/Resource.ts
+++ b/packages/upswyng-server/src/models/Resource.ts
@@ -56,11 +56,12 @@ export const resourceDocumentToResource = (
   if (r.toObject) {
     r = r.toObject();
   } else {
-    console.warn(
-      `\`resourceDocumentToResource\` received resource which does not appear to be a Mongoose Document [${Object.keys(
-        r
-      )}]:\n${JSON.stringify(r, null, 2)}`
-    );
+    // TODO (rhinodavid): Log formally or remove commented code
+    // console.warn(
+    //   `\`resourceDocumentToResource\` received resource which does not appear to be a Mongoose Document [${Object.keys(
+    //     r
+    //   )}]:\n${JSON.stringify(r, null, 2)}`
+    // );
   }
   const result = {
     _id: r._id.toHexString(),

--- a/packages/upswyng-server/src/models/Subcategory.ts
+++ b/packages/upswyng-server/src/models/Subcategory.ts
@@ -23,21 +23,22 @@ export function subcategoryDocumentToSubcategory(
   if (d.toObject) {
     s = d.toObject();
   } else {
-    console.warn(
-      `\`subcategoryDocumentToSubcategory\` received subcategory which does not appear to be a Mongoose Document [${Object.keys(
-        d
-      )}]:\n${JSON.stringify(d, null, 2)}`
-    );
-    if (d.hasOwnProperty("_bsontype")) {
-      console.warn("This appears to be an ObjectId");
-      console.trace();
-      return null;
-    }
-    if (Array.isArray(d)) {
-      console.warn("This appears to be an Array");
-      console.trace(d);
-      return null;
-    }
+    // Swallow for now
+    // console.warn(
+    //   `\`subcategoryDocumentToSubcategory\` received subcategory which does not appear to be a Mongoose Document [${Object.keys(
+    //     d
+    //   )}]:\n${JSON.stringify(d, null, 2)}`
+    // );
+    // if (d.hasOwnProperty("_bsontype")) {
+    //   console.warn("This appears to be an ObjectId");
+    //   console.trace();
+    //   return null;
+    // }
+    // if (Array.isArray(d)) {
+    //   console.warn("This appears to be an Array");
+    //   console.trace(d);
+    //   return null;
+    // }
   }
 
   let result: TSubcategory;

--- a/packages/upswyng-server/src/models/Utility.ts
+++ b/packages/upswyng-server/src/models/Utility.ts
@@ -161,6 +161,13 @@ export async function createOrUpdateResourceFromDraft(
   const existingResource = await Resource.findOne({
     resourceId: (draftResource as TResource).resourceId,
   }).populate("subcategories");
+  console.log("existing", existingResource);
+  const resourceBeforeEdits: TResourceDocument | null = existingResource
+    ? new Resource(
+        resourceToSchema(resourceDocumentToResource(existingResource))
+      )
+    : null;
+  console.log(resourceBeforeEdits);
   if (existingResource) {
     // update an existing resource
     const updateObject = diffResources(
@@ -219,5 +226,5 @@ export async function createOrUpdateResourceFromDraft(
       )
     );
   }
-  return existingResource;
+  return resourceBeforeEdits;
 }

--- a/packages/upswyng-server/src/models/Utility.ts
+++ b/packages/upswyng-server/src/models/Utility.ts
@@ -161,13 +161,11 @@ export async function createOrUpdateResourceFromDraft(
   const existingResource = await Resource.findOne({
     resourceId: (draftResource as TResource).resourceId,
   }).populate("subcategories");
-  console.log("existing", existingResource);
   const resourceBeforeEdits: TResourceDocument | null = existingResource
     ? new Resource(
         resourceToSchema(resourceDocumentToResource(existingResource))
       )
     : null;
-  console.log(resourceBeforeEdits);
   if (existingResource) {
     // update an existing resource
     const updateObject = diffResources(


### PR DESCRIPTION
Diffs being stored with Draft Approval Event Logs weren't being stored properly, and diffs with schedules weren't being shown correctly.