### PR TITLE
fix rendering of Weekly schedules

### DIFF
--- a/packages/upswyng-web/package.json
+++ b/packages/upswyng-web/package.json
@@ -9,7 +9,7 @@
     "@material-ui/lab": "^4.0.0-alpha.27",
     "@types/algoliasearch": "^3.30.12",
     "@types/enzyme": "^3.9.1",
-    "@types/enzyme-adapter-react-16": "^1.0.5",
+  "@types/enzyme-adapter-react-16": "^1.0.5",
     "@types/google-map-react": "^0.23.11",
     "@types/jest": "^24.0.11",
     "@types/material-ui": "^0.21.6",

--- a/packages/upswyng-web/src/components/Schedule.tsx
+++ b/packages/upswyng-web/src/components/Schedule.tsx
@@ -10,15 +10,19 @@ interface ScheduleProps {
   schedule: TResourceScheduleData;
 }
 
-const days = [
-  "Sunday",
-  "Monday",
-  "Tuesday",
-  "Wednesday",
-  "Thursday",
-  "Friday",
-  "Saturday",
-];
+const days = {
+  sunday: "SU",
+  monday: "MO",
+  tuesday: "TU",
+  wednesday: "WE",
+  thursday: "TH",
+  friday: "FR",
+  saturday: "SA",
+};
+
+function capitalize(x: string): string {
+  return x.charAt(0).toUpperCase() + x.slice(1);
+}
 
 const WeeklyContainer = styled.div`
   display: flex;
@@ -69,13 +73,15 @@ const WeeklyTime = styled.span`
 //   });
 
 const WeeklySchedule = ({ items }: { items: TScheduleItem[] }) => {
-  const dayItemsMap = days.map((day, dayIndex) => {
+  const dayItemsMap = Object.entries(days).map(([label, key]) => {
     return {
-      day,
+      day: label,
       items: items.filter(
         item =>
           item.recurrenceRule.options.freq === RRule.WEEKLY &&
-          item.recurrenceRule.options.byweekday.includes(dayIndex)
+          item.recurrenceRule.options.byweekday.includes(
+            (RRule as any)[key]["weekday"]
+          )
       ),
     };
   });
@@ -86,7 +92,7 @@ const WeeklySchedule = ({ items }: { items: TScheduleItem[] }) => {
         .filter(x => x.items.length)
         .map(x => (
           <WeeklyContainer key={x.day}>
-            <WeeklyDay>{x.day}</WeeklyDay>
+            <WeeklyDay>{capitalize(x.day)}</WeeklyDay>
             <WeeklyTimes>
               {x.items.map(i => (
                 <WeeklyTime key={`${i.fromTime.value}${i.toTime.value}`}>
@@ -118,8 +124,8 @@ const Schedule = ({ schedule }: ScheduleProps) => {
       <div>
         {Object.entries(commentMap).map(([comment, items]) => (
           <div key={comment}>
-            {comment !== "_no_comment_" && <div>{comment}</div>}
             <WeeklySchedule items={items as TScheduleItem[]} />
+            {comment !== "_no_comment_" && <div>{comment}</div>}
           </div>
         ))}
       </div>

--- a/packages/upswyng-web/src/components/Schedule.tsx
+++ b/packages/upswyng-web/src/components/Schedule.tsx
@@ -72,12 +72,11 @@ const WeeklySchedule = ({ items }: { items: TScheduleItem[] }) => {
   const dayItemsMap = days.map((day, dayIndex) => {
     return {
       day,
-      items: items.filter(item => {
-        return (
+      items: items.filter(
+        item =>
           item.recurrenceRule.options.freq === RRule.WEEKLY &&
           item.recurrenceRule.options.byweekday.includes(dayIndex)
-        );
-      }),
+      ),
     };
   });
 

--- a/packages/upswyng-web/src/components/Schedule.tsx
+++ b/packages/upswyng-web/src/components/Schedule.tsx
@@ -3,23 +3,23 @@ import { ResourceSchedule, TScheduleItem } from "@upswyng/upswyng-core";
 import { RRule } from "rrule";
 import React from "react";
 import { TResourceScheduleData } from "@upswyng/upswyng-types";
+import { font } from "../App.styles";
+import styled from "styled-components";
 
 interface ScheduleProps {
   schedule: TResourceScheduleData;
 }
 
-const dayToCode = {
-  sunday: "SU",
-  monday: "MO",
-  tuesday: "TU",
-  wednesday: "WE",
-  thursday: "TH",
-  friday: "FR",
-  saturday: "SA",
-};
+const days = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+];
 
-// TODO (rhinodavid): Remove these render functions
-/*
 const WeeklyContainer = styled.div`
   display: flex;
 `;
@@ -54,78 +54,48 @@ const WeeklyTime = styled.span`
   }
 `;
 
-const renderDaySchedule = (schedule: TSchedule[]) => {
-  const { day } = schedule[0];
-  return (
-    <WeeklyContainer key={day}>
-      <WeeklyDay>{day}</WeeklyDay>
-      <WeeklyTimes>
-        {schedule.map(({ day, from, to }) => (
-          <WeeklyTime key={`${day}-${from}`}>
-            {from} - {to}
-          </WeeklyTime>
-        ))}
-      </WeeklyTimes>
-    </WeeklyContainer>
-  );
-};
+// TODO (rhinodavid): Remove these render functions
 
-const renderWeeklySchedule = (schedule: TSchedule[]) => {
-  const renderedDays: (TDay | undefined)[] = [];
-
-  return schedule.map(({ day: currentDay }) => {
-    if (!renderedDays.includes(currentDay)) {
-      renderedDays.push(currentDay);
-      const currentDaySchedule = schedule.filter(
-        ({ day }) => day === currentDay
-      );
-      return renderDaySchedule(currentDaySchedule);
-    }
-    return null;
-  });
-};
-
-const renderMonthlySchedule = (schedule: TSchedule[]) =>
-  schedule.map(({ day, from, period, to }) => {
-    if (period) {
-      return (
-        <p key={`${period}-${day}-${from}`}>
-          every {period.toLowerCase()} {day} from {from} - {to}
-        </p>
-      );
-    }
-    return null;
-  });
-  */
+// const renderMonthlySchedule = (schedule: TSchedule[]) =>
+//   schedule.map(({ day, from, period, to }) => {
+//     if (period) {
+//       return (
+//         <p key={`${period}-${day}-${from}`}>
+//           every {period.toLowerCase()} {day} from {from} - {to}
+//         </p>
+//       );
+//     }
+//     return null;
+//   });
 
 const WeeklySchedule = ({ items }: { items: TScheduleItem[] }) => {
-  const dayItemsMap = Object.keys(dayToCode).map(day => {
+  const dayItemsMap = days.map((day, dayIndex) => {
     return {
       day,
-      items: items.filter(
-        item =>
+      items: items.filter(item => {
+        return (
           item.recurrenceRule.options.freq === RRule.WEEKLY &&
-          item.recurrenceRule.options.byweekday.includes(
-            (RRule as any)[dayToCode[day as keyof typeof dayToCode]] as number
-          )
-      ),
+          item.recurrenceRule.options.byweekday.includes(dayIndex)
+        );
+      }),
     };
   });
+
   return (
     <div>
       {dayItemsMap
         .filter(x => x.items.length)
         .map(x => (
-          <div key={x.day}>
-            <div>{x.day}</div>
-            <div>
+          <WeeklyContainer key={x.day}>
+            <WeeklyDay>{x.day}</WeeklyDay>
+            <WeeklyTimes>
               {x.items.map(i => (
-                <div key={`${i.fromTime.value}${i.toTime.value}`}>
+                <WeeklyTime key={`${i.fromTime.value}${i.toTime.value}`}>
                   {i.fromTime.label} - {i.toTime.label}
-                </div>
+                </WeeklyTime>
               ))}
-            </div>
-          </div>
+            </WeeklyTimes>
+          </WeeklyContainer>
         ))}
     </div>
   );
@@ -138,12 +108,12 @@ const Schedule = ({ schedule }: ScheduleProps) => {
     // group together schedule items that have the same comments
     const commentMap = resourceSchedule.getItems().reduce((result, item) => {
       const comment = item.comment || "_no_comment_";
-      result[comment as keyof typeof dayToCode] = [
-        ...(result[comment as keyof typeof dayToCode] || []),
+      result[comment as keyof typeof days] = [
+        ...(result[comment as keyof typeof days] || []),
         item,
       ];
       return result;
-    }, {} as Record<keyof typeof dayToCode, TScheduleItem[]>);
+    }, {} as Record<keyof typeof days, TScheduleItem[]>);
 
     return (
       <div>


### PR DESCRIPTION
This PR does not close an issue.

## What does this PR do?

Fixes the rendering of weekly schedules in the public section of the app.

<img width="351" alt="example of rendered weekly schedule" src="https://user-images.githubusercontent.com/6598084/71725181-04e23500-2e01-11ea-93d4-a2876a1f6ede.png">

_Note: This does not include monthly or annual schedules._

## How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![fixed it](https://media.giphy.com/media/iVDo6InQKyW8o/giphy.gif)
