### PR TITLE
🏗 Build upwsyng-types with rollup

### DIFF
--- a/packages/upswyng-types/package.json
+++ b/packages/upswyng-types/package.json
@@ -11,5 +11,10 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "rollup --config"
+  },
+  "devDependencies": {
+    "@rollup/plugin-node-resolve": "^6.1.0",
+    "rollup": "^1.28.0",
+    "rollup-plugin-typescript2": "^0.25.3"
   }
 }

--- a/packages/upswyng-types/package.json
+++ b/packages/upswyng-types/package.json
@@ -3,9 +3,13 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
+  "module": "dist/index.es.js",
+  "files": [
+    "dist"
+  ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc --build \"./tsconfig.build.json\""
+    "build": "rollup --config"
   }
 }

--- a/packages/upswyng-types/rollup.config.js
+++ b/packages/upswyng-types/rollup.config.js
@@ -1,5 +1,3 @@
-import commonjs from "@rollup/plugin-commonjs";
-import json from "@rollup/plugin-json";
 import pkg from "./package.json";
 import resolve from "@rollup/plugin-node-resolve";
 import typescript from "rollup-plugin-typescript2";
@@ -22,12 +20,6 @@ module.exports = {
       preferBuiltins: false,
     }),
     typescript({ tsconfig: "./tsconfig.build.json" }),
-    commonjs({
-      include: /node_modules/,
-      exclude: [/^.+\.tsx?$/],
-      namedExports: {},
-    }),
-    json(),
   ],
   external: [
     ...Object.keys(pkg.dependencies || {}),

--- a/packages/upswyng-types/rollup.config.js
+++ b/packages/upswyng-types/rollup.config.js
@@ -1,0 +1,36 @@
+import commonjs from "@rollup/plugin-commonjs";
+import json from "@rollup/plugin-json";
+import pkg from "./package.json";
+import resolve from "@rollup/plugin-node-resolve";
+import typescript from "rollup-plugin-typescript2";
+
+module.exports = {
+  input: "src/index.ts",
+  output: [
+    {
+      file: pkg.main,
+      format: "cjs",
+    },
+    {
+      file: pkg.module,
+      format: "es",
+    },
+  ],
+  plugins: [
+    resolve({
+      browser: true,
+      preferBuiltins: false,
+    }),
+    typescript({ tsconfig: "./tsconfig.build.json" }),
+    commonjs({
+      include: /node_modules/,
+      exclude: [/^.+\.tsx?$/],
+      namedExports: {},
+    }),
+    json(),
+  ],
+  external: [
+    ...Object.keys(pkg.dependencies || {}),
+    ...Object.keys(pkg.peerDependencies || {}),
+  ],
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1466,6 +1466,17 @@
     is-module "^1.0.0"
     resolve "^1.11.1"
 
+"@rollup/plugin-node-resolve@^6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-6.1.0.tgz#0d2909f4bf606ae34d43a9bc8be06a9b0c850cf0"
+  integrity sha512-Cv7PDIvxdE40SWilY5WgZpqfIUEaDxFxs89zCAHjqyRwlTSuql4M5hjIuc5QYJkOH0/vyiyNXKD72O+LhRipGA==
+  dependencies:
+    "@rollup/pluginutils" "^3.0.0"
+    "@types/resolve" "0.0.8"
+    builtin-modules "^3.1.0"
+    is-module "^1.0.0"
+    resolve "^1.11.1"
+
 "@rollup/plugin-replace@^2.3.0":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-replace/-/plugin-replace-2.3.0.tgz#86d88746383e40dd81cffb5216449cc51a734eb9"
@@ -13403,6 +13414,15 @@ rollup@^1.12.0, rollup@^1.27.8:
   version "1.27.14"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.27.14.tgz#940718d5eec1a6887e399aa0089944bae5c4f377"
   integrity sha512-DuDjEyn8Y79ALYXMt+nH/EI58L5pEw5HU9K38xXdRnxQhvzUTI/nxAawhkAHUQeudANQ//8iyrhVRHJBuR6DSQ==
+  dependencies:
+    "@types/estree" "*"
+    "@types/node" "*"
+    acorn "^7.1.0"
+
+rollup@^1.28.0:
+  version "1.28.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.28.0.tgz#d576a6a0fd7490b2e1f531ef8b411795fb80da87"
+  integrity sha512-v2J/DmQi9+Nf6frGqzwZRvbiuTTrqH0yzoUF4Eybf8sONT4UpLZzJYnYzW96Zm9X1+4SJmijfnFBWCzHDAXYnQ==
   dependencies:
     "@types/estree" "*"
     "@types/node" "*"


### PR DESCRIPTION
Previously build was done just using typescript, but not producing a
commonjs module and an esm module was causing problems down the road.

The rollup config is branched from that of upswyng-core and is basically
the same, just pared down a bit.