### PR TITLE
💄 [server] Tweak the behavior of sked weekly repeat selector

### DIFF
--- a/packages/upswyng-server/src/components/ScheduleSelector.svelte
+++ b/packages/upswyng-server/src/components/ScheduleSelector.svelte
@@ -127,12 +127,12 @@
 
   const certainWeekRepeatStateDefault = {
     everyWeek: true,
-    1: true, // first <sunday, monday, ... saturday> of month
-    2: true, // second of month
-    3: true,
-    4: true,
-    [-2]: true, // second to last of month
-    [-1]: true, // last of month,
+    1: false, // first <sunday, monday, ... saturday> of month
+    2: false, // second of month
+    3: false,
+    4: false,
+    [-2]: false, // second to last of month
+    [-1]: false, // last of month,
   };
 
   let weeklyRepeatState = Object.assign({}, weeklyRepeatStateDefault);
@@ -319,7 +319,9 @@
                   certainWeekRepeatState = { ...certainWeekRepeatStateDefault };
                 }}
                 title="Select all occurances of the day">
-                <span>All</span>
+                <span>
+                  <strong>All</strong>
+                </span>
               </button>
             </p>
             {#each [{ name: 'First', value: 1 }, { name: 'Second', value: 2 }, { name: 'Third', value: 3 }, { name: 'Fourth', value: 4 }, { name: 'Last', value: -1 }, { name: 'Second-to-last', value: -2 }] as entry}


### PR DESCRIPTION
The selector to pick certain weeks of the month had some wonky behavior. Now, "All" starts off as selected and then once any single week is selected "All" becomes unselected. If "All" is pressed later all the individual weeks will be unselected.
<img width="548" alt="Screen Shot 2020-01-05 at 9 26 23 PM" src="https://user-images.githubusercontent.com/5778036/71795464-86a1b080-3003-11ea-8ab2-4c3afaa83e5f.png">
<img width="566" alt="Screen Shot 2020-01-05 at 9 26 36 PM" src="https://user-images.githubusercontent.com/5778036/71795468-87d2dd80-3003-11ea-8cf8-6515d1b9d097.png">
