### PR TITLE
💄 [server] Always show issues for resource

### DIFF
--- a/packages/upswyng-server/src/routes/api/resource/issues/[resourceId].ts
+++ b/packages/upswyng-server/src/routes/api/resource/issues/[resourceId].ts
@@ -1,11 +1,13 @@
 import ResourceIssue, {
   resourceIssueDocumentToResourceIssue,
 } from "../../../../models/ResourceIssue";
+
 import { ObjectId } from "bson";
 import { requireAdmin } from "../../../../utility/authHelpers";
 
 /**
- *  Fetch all the Issues for the resource specified by the Resource ID.
+ *  Fetch all the Issues for the resource specified by the Resource ID. Set the
+ * `include_resolved` query param to `true` to fetch both resolved and unresolved issues.
  */
 export async function get(req, res, _next) {
   try {
@@ -25,8 +27,10 @@ export async function get(req, res, _next) {
   const { resourceId } = req.params;
 
   try {
+    const includeResolved = Boolean(req.query.include_resolved);
     const resourceIssueDocuments = await ResourceIssue.getForResource(
-      ObjectId.createFromHexString(resourceId)
+      ObjectId.createFromHexString(resourceId),
+      includeResolved
     );
 
     res.writeHead(200, {

--- a/packages/upswyng-server/src/routes/resource/[resourceId].svelte
+++ b/packages/upswyng-server/src/routes/resource/[resourceId].svelte
@@ -99,7 +99,7 @@
 
   function loadIssues() {
     isLoadingIssues = true;
-    fetch(`/api/resource/issues/${resource.resourceId}`)
+    fetch(`/api/resource/issues/${resource.resourceId}?include_resolved=true`)
       .then(async response => {
         const { resourceIssues } = await response.json();
         if (response.status !== 200 || !resourceIssues) {
@@ -143,7 +143,7 @@
           </div>
           <progress class="progress is-small" max="100" />
         </div>
-      {:else if issues && issues.length}
+      {:else if issues && issues.filter(i => !i.resolved).length}
         <div class="notification is-warning found-issues">
           <div class="notification-text">
             <span class="has-text-weight-medium">
@@ -169,7 +169,7 @@
         errorText={saveError ? saveError.message : ''}
         on:clearErrorText={() => (saveError = null)}
         on:dispatchSaveResource={e => handleSaveClick(e.detail)} />
-      {#if isAdmin && issues}
+      {#if isAdmin && issues && issues.length}
         <h1 id="issues" class="title">Issues</h1>
         {#each issues as issue (issue._id)}
           <ResourceIssueNotification resourceIssue={issue} />


### PR DESCRIPTION
[This all applies to admins only] Previous behavior was only to show unresolved issues on the the resource page. (Also there was a bug where the "Issues" header would show even with no issues.) The new behavior is:
- show banner when unresolved issues exist
- show all issues at the bottom, even the resolved ones
- hide the header if there are no issues
