### PR TITLE
✨ [server] Show related event logs on resource page

### DIFF
--- a/packages/upswyng-server/src/components/EventLogs.svelte
+++ b/packages/upswyng-server/src/components/EventLogs.svelte
@@ -1,0 +1,109 @@
+<script>
+  import EventLogItem from "./EventLogItem.svelte";
+
+  export let resourceId /* string | null */ = null;
+
+  let estimatedTotal = Infinity;
+  let fetchedAll = false; // if we execute a fetch and we don't get any additional logs, set this to true and hide the "load more" buttons
+  let limit = 10;
+  let offset = 0;
+  let offsetStep = 5;
+  let errorMessage = "";
+  let eventLogs = [];
+  let isLoading = true; // prevent drawing flicker at start
+
+  async function fetchEventLogs(limit, offset, resourceId) {
+    errorMessage = "";
+    isLoading = true;
+    let response;
+    try {
+      response = await fetch(`/api/eventlogs`, {
+        method: "POST",
+        body: JSON.stringify({
+          limit,
+          offset,
+          resourceId,
+        }),
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+      const {
+        eventLogs: newEventLogs,
+        estimatedTotal: newEstimatedTotal,
+        message,
+      } = await response.json();
+      if (response.status !== 200) {
+        throw new Error(message || "Error getting Resource Issues");
+      }
+      if (!newEventLogs.length) {
+        fetchedAll = true;
+      }
+      eventLogs = eventLogs.concat(newEventLogs);
+      estimatedTotal = newEstimatedTotal;
+    } catch (e) {
+      errorMessage = e.message;
+    } finally {
+      isLoading = false;
+    }
+  }
+
+  fetchEventLogs(limit, offset, resourceId);
+</script>
+
+<style>
+  .spinner {
+    animation-duration: 0.75s;
+    animation-iteration-count: infinite;
+    animation-name: spin;
+    animation-timing-function: linear;
+    display: inline-block;
+    transform-origin: 50% 50%;
+  }
+  @keyframes spin {
+    0% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+</style>
+
+<div class="content">
+  {#if errorMessage}
+    <div class="notification is-danger">{errorMessage}</div>
+  {/if}
+  {#if !eventLogs.length && isLoading}
+    <progress class="progress is-small is-primary" max="100" />
+  {:else if !eventLogs.length && !isLoading}
+    <div class="has-text-grey is-italic has-text-weight-semibold is-size-6">
+      No events to show
+    </div>
+  {:else}
+    <div class="timeline">
+      {#each eventLogs as eventLog}
+        <EventLogItem {eventLog} />
+      {/each}
+      {#if eventLogs.length < estimatedTotal && !fetchedAll}
+        <div class="content has-text-centered">
+          {#if !isLoading}
+            <!-- svelte-ignore a11y-missing-attribute -->
+            <a
+              on:click|preventDefault={() => {
+                offset += offsetStep;
+                fetchEventLogs(limit, offset, resourceId);
+              }}
+              class="is-uppercase is-size-7 has-text-weight-bold">
+              Load More
+            </a>
+          {:else}
+            <div class="is-loading has-text-primary">
+              <i class="fas fa-spinner spinner" />
+            </div>
+          {/if}
+        </div>
+      {/if}
+    </div>
+  {/if}
+</div>

--- a/packages/upswyng-server/src/components/Nav.svelte
+++ b/packages/upswyng-server/src/components/Nav.svelte
@@ -54,10 +54,12 @@
         <div class="navbar-dropdown">
           {#if user && user.isAdmin}
             <a class="navbar-item" href="resource/issues" rel="prefetch">
-              Issues
+              <span>Issues &nbsp;</span>
+              <span class="tag is-dark">Admin</span>
             </a>
             <a class="navbar-item" href="eventlogs" rel="prefetch">
-              Event Logs
+              <span>Event Logs &nbsp;</span>
+              <span class="tag is-dark">Admin</span>
             </a>
             <hr class="navbar-divider" />
           {/if}
@@ -79,14 +81,16 @@
         <div class="navbar-item">
           <span class="has-text-weight-semibold">{user.name}</span>
           {#if user && user.isAdmin}
-            <span class="has-text-weight-light">&nbsp;[admin]</span>
+            &nbsp;&nbsp;&nbsp;
+            <span class="tag is-black">Admin</span>
           {/if}
         </div>
       {:else if user && user.email}
         <div class="navbar-item">
           <span class="has-text-weight-semibold">{user.email}</span>
           {#if user && user.isAdmin}
-            <span class="has-text-weight-light">&nbsp;[admin]</span>
+            &nbsp;&nbsp;&nbsp;
+            <span class="tag is-black">Admin</span>
           {/if}
         </div>
       {/if}

--- a/packages/upswyng-server/src/routes/api/eventlogs.ts
+++ b/packages/upswyng-server/src/routes/api/eventlogs.ts
@@ -7,6 +7,7 @@ import { requireAdmin } from "../../utility/authHelpers";
  * {
  *   limit: number, // default 20
  *   offset: number, // default 0
+ *   resourceId?: string, // if provided, returns events with the given resource ID in the detail
  * }
  *
  * The response has the shape of:
@@ -33,7 +34,12 @@ export async function post(req, res, _next) {
   const offset = req.body.offset || 0;
 
   try {
-    const issues = await EventLog.find({})
+    const query = req.body.resourceId
+      ? {
+          "detail.resourceId": req.body.resourceId,
+        }
+      : {};
+    const issues = await EventLog.find(query)
       .populate("actor")
       .skip(offset)
       .limit(limit)

--- a/packages/upswyng-server/src/routes/eventlogs.svelte
+++ b/packages/upswyng-server/src/routes/eventlogs.svelte
@@ -7,69 +7,8 @@
 </script>
 
 <script>
-  import EventLogItem from "../components/EventLogItem.svelte";
-
-  let estimatedTotal = Infinity;
-  let limit = 7;
-  let offset = 0;
-  let offsetStep = 5;
-  let errorMessage = "";
-  let eventLogs = [];
-  let isLoading = true; // prevent drawing flicker at start
-
-  async function fetchEventLogs(limit, offset) {
-    errorMessage = "";
-    isLoading = true;
-    let response;
-    try {
-      response = await fetch(`/api/eventlogs`, {
-        method: "POST",
-        body: JSON.stringify({
-          limit,
-          offset,
-        }),
-        headers: {
-          "Content-Type": "application/json",
-        },
-      });
-      const {
-        eventLogs: newEventLogs,
-        estimatedTotal: newEstimatedTotal,
-        message,
-      } = await response.json();
-      if (response.status !== 200) {
-        throw new Error(message || "Error getting Resource Issues");
-      }
-      eventLogs = eventLogs.concat(newEventLogs);
-      estimatedTotal = newEstimatedTotal;
-    } catch (e) {
-      errorMessage = e.message;
-    } finally {
-      isLoading = false;
-    }
-  }
-
-  fetchEventLogs(limit, offset);
+  import EventLogs from "../components/EventLogs.svelte";
 </script>
-
-<style>
-  .spinner {
-    animation-duration: 0.75s;
-    animation-iteration-count: infinite;
-    animation-name: spin;
-    animation-timing-function: linear;
-    display: inline-block;
-    transform-origin: 50% 50%;
-  }
-  @keyframes spin {
-    0% {
-      transform: rotate(0deg);
-    }
-    100% {
-      transform: rotate(360deg);
-    }
-  }
-</style>
 
 <svelte:head>
   <title>UpSwyng: Event Logs</title>
@@ -77,41 +16,10 @@
 
 <section class="section">
   <div class="container">
-    <h1 class="title">Event Logs</h1>
-    {#if errorMessage}
-      <div class="notification is-danger">{errorMessage}</div>
-    {/if}
-    {#if !eventLogs.length && isLoading}
-      <progress class="progress is-small is-primary" max="100" />
-    {:else if !eventLogs.length && !isLoading}
-      <div class="has-text-grey is-italic has-text-weight-semibold is-size-6">
-        No events to show
-      </div>
-    {:else}
-      <div class="timeline">
-        {#each eventLogs as eventLog}
-          <EventLogItem {eventLog} />
-        {/each}
-        {#if eventLogs.length < estimatedTotal}
-          <div class="content has-text-centered">
-            {#if !isLoading}
-              <!-- svelte-ignore a11y-missing-attribute -->
-              <a
-                on:click|preventDefault={() => {
-                  offset += offsetStep;
-                  fetchEventLogs(limit, offset);
-                }}
-                class="is-uppercase is-size-7 has-text-weight-bold">
-                Load More
-              </a>
-            {:else}
-              <div class="is-loading has-text-primary">
-                <i class="fas fa-spinner spinner" />
-              </div>
-            {/if}
-          </div>
-        {/if}
-      </div>
-    {/if}
+    <h1 class="title">
+      Event Logs
+      <span class="tag is-dark">Admin</span>
+    </h1>
+    <EventLogs />
   </div>
 </section>

--- a/packages/upswyng-server/src/routes/resource/[resourceId].svelte
+++ b/packages/upswyng-server/src/routes/resource/[resourceId].svelte
@@ -29,10 +29,11 @@
 <script>
   import { addFlashMessage } from "../../utility/flashMessage.ts";
   import { goto, stores } from "@sapper/app";
-  import ResourceDisplay from "../../components/ResourceDisplay.svelte";
-  import ResourceEditor from "../../components/ResourceEditor.svelte";
   import { onMount } from "svelte";
   import * as animateScroll from "svelte-scrollto";
+  import EventLogs from "../../components/EventLogs.svelte";
+  import ResourceDisplay from "../../components/ResourceDisplay.svelte";
+  import ResourceEditor from "../../components/ResourceEditor.svelte";
   import ResourceIssueNotification from "../../components/ResourceIssueNotification.svelte";
 
   const { session } = stores();
@@ -173,7 +174,10 @@
         on:clearErrorText={() => (saveError = null)}
         on:dispatchSaveResource={e => handleSaveClick(e.detail)} />
       {#if isAdmin && issues && issues.length}
-        <h1 id="issues" class="title">Issues</h1>
+        <h1 id="issues" class="title">
+          Issues
+          <span class="tag is-dark">Admin</span>
+        </h1>
         {#each issues as issue (issue._id)}
           <ResourceIssueNotification resourceIssue={issue} />
         {/each}
@@ -182,5 +186,14 @@
       <ResourceDisplay {resource} />
       <div class="notification">Log in to make changes to this resource</div>
     {/if}
+
+    {#if isAdmin}
+      <h1 class="title">
+        Event Logs
+        <span class="tag is-dark">Admin</span>
+      </h1>
+      <EventLogs resourceId={resource.resourceId} />
+    {/if}
+
   </div>
 </section>

--- a/packages/upswyng-server/src/routes/resource/draft/[_id].svelte
+++ b/packages/upswyng-server/src/routes/resource/draft/[_id].svelte
@@ -125,7 +125,10 @@
 <section class="section">
   <div class="container">
     {#if existingResource}
-      <h1 class="title">Update Resource: {existingResource.name}</h1>
+      <h1 class="title">
+        Update Resource: {existingResource.name}
+        <span class="tag is-dark">Admin</span>
+      </h1>
       <p class="subtitle">
         Resource ID:
         <a href={`/resource/${existingResource.resourceId}`}>
@@ -136,7 +139,10 @@
         leftResource={existingResource}
         rightResource={draftResource} />
     {:else}
-      <h1 class="title">Create New Resource</h1>
+      <h1 class="title">
+        Create New Resource
+        <span class="tag is-dark">Admin</span>
+      </h1>
       <ResourceDisplay resource={draftResource} />
     {/if}
 

--- a/packages/upswyng-server/src/routes/resource/index.svelte
+++ b/packages/upswyng-server/src/routes/resource/index.svelte
@@ -6,15 +6,10 @@
     const { uncategorizedResources } = await this.fetch(
       "/api/resources/uncategorized"
     ).then(r => r.json());
-    // TODO: Remove displaying all resources once they get too big
-    const { resources: allResources } = await this.fetch(
-      "/api/resources"
-    ).then(r => r.json());
-    const { draftResources } = await this.fetch(
-      "/api/resources/drafts"
-    ).then(r => r.json());
+    const { draftResources } = await this.fetch("/api/resources/drafts").then(
+      r => r.json()
+    );
     return {
-      allResources,
       categories,
       draftResources,
       uncategorizedResources,
@@ -34,7 +29,6 @@
   export let categories = null;
   export let draftResources = null;
   export let uncategorizedResources = null;
-  export let allResources = null;
   export let user = null;
 </script>
 
@@ -71,7 +65,7 @@
 
     <div class="content">
       {#if categories.length}
-        <p class="subtitle">Resource Categories</p>
+        <h2 class="subtitle">Categories</h2>
         <ul class="content">
           {#each categories as category}
             <li>
@@ -86,7 +80,10 @@
 
     {#if user && user.isAdmin}
       <div class="content">
-        <p class="subtitle">Draft Resources</p>
+        <h2 class="subtitle">
+          Draft Resources
+          <span class="tag is-dark">Admin</span>
+        </h2>
         {#if draftResources.length}
           <ul class="content">
             {#each draftResources as draftResource}
@@ -104,7 +101,7 @@
     {/if}
 
     <div class="content">
-      <p class="subtitle">Search for a Resource</p>
+      <h2 class="subtitle">Search for a Resource</h2>
       <ResourceSearch
         action="view"
         on:resourceClick={({ detail: resourceId }) => {
@@ -114,7 +111,10 @@
 
     {#if uncategorizedResources.length && user && user.isAdmin}
       <div class="content">
-        <p class="subtitle">Uncategorized Resources</p>
+        <h2 class="subtitle">
+          Uncategorized Resources
+          <span class="tag is-dark">Admin</span>
+        </h2>
         <ul class="content">
           {#each uncategorizedResources as resource}
             <li>

--- a/packages/upswyng-server/src/routes/resource/index.svelte
+++ b/packages/upswyng-server/src/routes/resource/index.svelte
@@ -6,9 +6,9 @@
     const { uncategorizedResources } = await this.fetch(
       "/api/resources/uncategorized"
     ).then(r => r.json());
-    const { draftResources } = await this.fetch("/api/resources/drafts").then(
-      r => r.json()
-    );
+    const { draftResources } = await this.fetch(
+      "/api/resources/drafts"
+    ).then(r => r.json());
     return {
       categories,
       draftResources,

--- a/packages/upswyng-server/src/routes/resource/issue/[resource_issue_id].svelte
+++ b/packages/upswyng-server/src/routes/resource/issue/[resource_issue_id].svelte
@@ -63,7 +63,10 @@
 
 <section class="section">
   {#if resource}
-    <h1 class="title">{resource.name}</h1>
+    <h1 class="title">
+      {resource.name}
+      <span class="tag is-dark">Admin</span>
+    </h1>
     <p class="content has-text-weight-semibold">
       <a href={`/resource/${resource.resourceId}`} rel="prefetch">
         {resource.resourceId}

--- a/packages/upswyng-server/src/routes/resource/issues/index.svelte
+++ b/packages/upswyng-server/src/routes/resource/issues/index.svelte
@@ -2,6 +2,10 @@
   import { ResourceSchedule } from "@upswyng/upswyng-core";
 
   export async function preload({ params, query }, { user }) {
+    if (!user || !user.isAdmin) {
+      this.error(401, "You must be an admin to access this page.");
+    }
+
     const resourceIdToNameMap = new Map();
     let resourceIssuesResponse;
     try {
@@ -227,7 +231,10 @@
 
 <section class="section">
   <div class="container">
-    <h1 class="title">Resource Issues</h1>
+    <h1 class="title">
+      Resource Issues
+      <span class="tag is-dark">Admin</span>
+    </h1>
     {#if errorMessage}
       <div class="notification is-danger">
         <button


### PR DESCRIPTION
- Show a subset of event logs relating to a resource on the resource page
- Add a tag/badge next to everything that only admins can see so that it's clear the feature is admin-only
<img width="854" alt="Screen Shot 2020-01-07 at 11 53 19 PM" src="https://user-images.githubusercontent.com/5778036/71956789-4714c900-31a9-11ea-8804-1f7a319b431a.png">
