### PR TITLE
🐛 [server] Disable service worker caching for auth routes

### DIFF
--- a/packages/upswyng-server/src/routes/logout.ts
+++ b/packages/upswyng-server/src/routes/logout.ts
@@ -1,8 +1,11 @@
+/**
+ * API route used to destroy current session and therefore log user out of UpSwyng
+ */
 export function get(req, res, _next) {
   req.session.destroy((e: Error | null) => {
     if (e) {
       console.log("Error destroying session:\n", e);
     }
+    res.redirect(302, "/"); // use temporary redirect to prevent caching
   });
-  res.redirect(301, "/");
 }

--- a/packages/upswyng-server/src/service-worker.js
+++ b/packages/upswyng-server/src/service-worker.js
@@ -47,6 +47,10 @@ self.addEventListener("fetch", event => {
   )
     return;
 
+  // ignore authentication (login/logout)
+  if (url.pathname.includes("/logout") || url.pathname.includes("/connect"))
+    return;
+
   // always serve static files and bundler-generated assets from cache
   if (url.host === self.location.host && cached.has(url.pathname)) {
     event.respondWith(caches.match(event.request));

--- a/packages/upswyng-server/src/utility/userMiddleware.ts
+++ b/packages/upswyng-server/src/utility/userMiddleware.ts
@@ -6,6 +6,7 @@ import User, { userDocumentToUser } from "../models/User";
 
 import { TUser } from "@upswyng/upswyng-types";
 import axios from "axios";
+
 interface TGrantGoogle {
   provider: "google";
   state: "string";
@@ -39,6 +40,15 @@ async function googleGrantToUser(grant: TGrantGoogle): Promise<TUser> {
     );
   }
   try {
+    if (!grant.response.id_token) {
+      throw new Error(
+        `No id_token included with response. Grant:\n${JSON.stringify(
+          grant,
+          null,
+          2
+        )}`
+      );
+    }
     const user = await User.findOrCreateGoogleUser(
       grant.response.id_token.payload.sub,
       grant.response.id_token.payload.email
@@ -47,7 +57,7 @@ async function googleGrantToUser(grant: TGrantGoogle): Promise<TUser> {
   } catch (e) {
     console.error(e);
     throw new Error(
-      `Error creating or finding new user with sub ${grant.response.id_token.payload.sub}`
+      `Error creating or finding new user with sub ${grant.response.id_token.payload.sub}:\n${e}`
     );
   }
 }


### PR DESCRIPTION
Disable Sapper service-worker caching for auth routes. Add some logging for when grant `id_token` is not defined. #230 