### PR TITLE
🐛 [server] Separate middleware layers

### DIFF
--- a/packages/upswyng-server/src/app.ts
+++ b/packages/upswyng-server/src/app.ts
@@ -34,16 +34,18 @@ export default function(options: TAppOptions) {
       cors(), // TODO: Lock this down to non-admin routes
       sirv("static", { dev }),
       bodyParser.urlencoded({ extended: true }),
-      bodyParser.json(),
+      bodyParser.json()
+    )
+    .use(
       session({
         store: new MongoStore({ mongooseConnection }),
         secret: sessionSecret,
-        saveUninitialized: false,
-        resave: false,
-      }),
-      grant(grantConfig),
-      userMiddleware
+        saveUninitialized: true,
+        resave: true,
+      })
     )
+    .use(grant(grantConfig))
+    .use(userMiddleware)
     .get("/callback", oidc(grantConfig), (_req, res) => {
       res.redirect("/");
     });


### PR DESCRIPTION
Still desperately trying to fix #230. I'm not even sure if this is necessary, but I want to try to fix the order of the `session` and `grant` middlewares and not have them in a race condition.