### PR TITLE
feat: update the resource ID to use a slug rather than search param

### DIFF
--- a/packages/upswyng-web/src/App.tsx
+++ b/packages/upswyng-web/src/App.tsx
@@ -47,7 +47,7 @@ class App extends Component {
             <Route path="/food" component={Food} />
             <Route exact path="/privacy-policy" component={PrivacyPolicy} />
             <Route path="/transit" component={Transit} />
-            <Route exact path="/resource" component={Resource} />
+            <Route exact path="/resource/:resourceId" component={Resource} />
             <Route path="/resources" component={Resources} />
             <Route path="/social_services" component={SocialServices} />
             <Route exact path="/search" component={Search} />

--- a/packages/upswyng-web/src/components/Resource.tsx
+++ b/packages/upswyng-web/src/components/Resource.tsx
@@ -58,10 +58,6 @@ export const Resource = () => {
   const resource = useResource(resourceId || "");
   const listIconClasses = useListIconStyles({});
 
-  if (!resourceId) {
-    return <p>We&apos;re sorry, this resource was not found.</p>;
-  }
-
   if (resource === undefined) {
     return <LoadingSpinner />;
   }

--- a/packages/upswyng-web/src/components/Resource.tsx
+++ b/packages/upswyng-web/src/components/Resource.tsx
@@ -13,15 +13,14 @@ import PageBanner from "./PageBanner";
 import PhoneIcon from "@material-ui/icons/Phone";
 import PublicIcon from "@material-ui/icons/Public";
 import React from "react";
-import { SEARCH_PARAM_RESOURCE } from "../constants";
 import Schedule from "./Schedule";
 import ScheduleIcon from "@material-ui/icons/Schedule";
 import Services from "./Services";
 import { TResource } from "@upswyng/upswyng-types";
 import { Theme } from "@material-ui/core/styles/createMuiTheme";
 import Typography from "@material-ui/core/Typography";
-import { getSearchParamVal } from "../utils/searchParams";
 import makeStyles from "@material-ui/core/styles/makeStyles";
+import { useParams } from "react-router-dom";
 import useResource from "./useResource";
 
 const useListIconStyles = makeStyles((theme: Theme) => ({
@@ -54,9 +53,9 @@ const getMainCategory = (categoryStub: string): TCategoryDefinition | null => {
 };
 
 export const Resource = () => {
-  const resourceId = getSearchParamVal(SEARCH_PARAM_RESOURCE);
-  const resource = useResource(resourceId || "");
+  const { resourceId } = useParams();
   const { currentBannerColor } = React.useContext(BannerColorContext);
+  const resource = useResource(resourceId || "");
   const listIconClasses = useListIconStyles({});
 
   if (!resourceId) {

--- a/packages/upswyng-web/src/components/ResourceCard.tsx
+++ b/packages/upswyng-web/src/components/ResourceCard.tsx
@@ -2,7 +2,6 @@ import { colors, font } from "../App.styles";
 
 import { Link } from "react-router-dom";
 import React from "react";
-import { SEARCH_PARAM_RESOURCE } from "../constants";
 import styled from "styled-components";
 
 interface Props {
@@ -126,8 +125,7 @@ const ResourceCard = ({
   return (
     <ResourceCardContainer
       to={{
-        pathname: "/resource",
-        search: `?${SEARCH_PARAM_RESOURCE}=${resourceId}`,
+        pathname: `/resource/${resourceId}`,
       }}
     >
       <ResourceCardImageContainer>

--- a/packages/upswyng-web/src/components/__tests__/Resource.test.tsx
+++ b/packages/upswyng-web/src/components/__tests__/Resource.test.tsx
@@ -25,8 +25,8 @@ jest.mock("../../App.styles", () => ({
     },
   },
 }));
-jest.mock("../../utils/searchParams", () => ({
-  getSearchParamVal: () => "some resource ID",
+jest.mock("react-router-dom", () => ({
+  useParams: () => ({ resourceId: "some resource ID" }),
 }));
 jest.mock("../PageBanner", () => "PageBanner");
 jest.mock("../Schedule", () => "Schedule");

--- a/packages/upswyng-web/src/constants.ts
+++ b/packages/upswyng-web/src/constants.ts
@@ -1,2 +1,1 @@
-export const SEARCH_PARAM_RESOURCE = "id";
 export const SEARCH_PARAM_QUERY = "q";


### PR DESCRIPTION
This PR does not close an issue.

## What does this PR do?

Updates the resource ID to use a slug rather than a search param value.

So instead of this URL:
`https://upswyng.org/resource?id=123456`

You'll have this URL:
`https://upswyng.org/resource/123456`

## How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/X7jjWeC03QDT2/giphy.gif)
