### PR TITLE
feat: add coordinated entry page

### DIFF
--- a/packages/upswyng-web/src/App.tsx
+++ b/packages/upswyng-web/src/App.tsx
@@ -40,7 +40,7 @@ class App extends Component {
             <Route exact path="/about" component={About} />
             <Route path="/coordinated-entry" component={CoordinatedEntry} />
             <Route path="/shelters" component={Shelters} />
-            <Route path="/job_training" component={JobTraining} />
+            <Route path="/job-training" component={JobTraining} />
             <Route path="/health" component={Health} />
             <Route path="/hygiene" component={Hygiene} />
             <Route exact path="/hotlines" component={Hotlines} />

--- a/packages/upswyng-web/src/App.tsx
+++ b/packages/upswyng-web/src/App.tsx
@@ -4,6 +4,7 @@ import { Route, BrowserRouter as Router } from "react-router-dom";
 import About from "./components/About";
 import { BannerColorContextProvider } from "./components/BannerColorContext";
 import Categories from "./components/Categories";
+import CoordinatedEntry from "./components/CoordinatedEntry";
 import GlobalStyle from "./App.styles";
 import Header from "./components/Header";
 import Home from "./components/Home";
@@ -37,6 +38,7 @@ class App extends Component {
             <Header />
             <Route exact path="/" component={Home} />
             <Route exact path="/about" component={About} />
+            <Route path="/coordinated-entry" component={CoordinatedEntry} />
             <Route path="/shelters" component={Shelters} />
             <Route path="/job_training" component={JobTraining} />
             <Route path="/health" component={Health} />

--- a/packages/upswyng-web/src/components/CoordinatedEntry.tsx
+++ b/packages/upswyng-web/src/components/CoordinatedEntry.tsx
@@ -1,0 +1,11 @@
+import { Container } from "../App.styles";
+import React from "react";
+import Typography from "@material-ui/core/Typography";
+
+const CoordinatedEntry = () => (
+  <Container>
+    <Typography variant="h1">Coordinated Entry</Typography>
+  </Container>
+);
+
+export default CoordinatedEntry;

--- a/packages/upswyng-web/src/components/CoordinatedEntry.tsx
+++ b/packages/upswyng-web/src/components/CoordinatedEntry.tsx
@@ -1,10 +1,42 @@
+import Card from "@material-ui/core/Card";
 import { Container } from "../App.styles";
+import List from "@material-ui/core/List";
+import ListItem from "@material-ui/core/ListItem";
+import ListItemIcon from "@material-ui/core/ListItemIcon";
+import ListItemText from "@material-ui/core/ListItemText";
 import React from "react";
 import Typography from "@material-ui/core/Typography";
+import WarningIcon from "@material-ui/icons/Warning";
 
 const CoordinatedEntry = () => (
   <Container>
-    <Typography variant="h1">Coordinated Entry</Typography>
+    <Typography variant="h1" gutterBottom>
+      Coordinated Entry
+    </Typography>
+
+    <Typography paragraph>
+      All single homeless adults must go through the Coordinated Entry process
+      to receive services from Boulder County or the cities of Boulder or
+      Longmont. After meeting with a staff person and going through a short
+      screening, clients will be referred to the most appropriate service
+      depending on their needs.
+    </Typography>
+    <Card elevation={1} variant="outlined" square>
+      <List>
+        <ListItem>
+          <ListItemIcon>
+            <WarningIcon color="primary" fontSize="large" />
+          </ListItemIcon>
+          <ListItemText>
+            <Typography>
+              Note you must have been in Boulder County for 6 months before
+              applying. If you apply before 6 months, you will be barred from
+              any services.
+            </Typography>
+          </ListItemText>
+        </ListItem>
+      </List>
+    </Card>
   </Container>
 );
 

--- a/packages/upswyng-web/src/components/CoordinatedEntry.tsx
+++ b/packages/upswyng-web/src/components/CoordinatedEntry.tsx
@@ -1,43 +1,67 @@
+import { Container, colors } from "../App.styles";
+import Button from "@material-ui/core/Button";
 import Card from "@material-ui/core/Card";
-import { Container } from "../App.styles";
+import ExitToAppIcon from "@material-ui/icons/ExitToApp";
 import List from "@material-ui/core/List";
 import ListItem from "@material-ui/core/ListItem";
 import ListItemIcon from "@material-ui/core/ListItemIcon";
 import ListItemText from "@material-ui/core/ListItemText";
+import PageBanner from "./PageBanner";
 import React from "react";
 import Typography from "@material-ui/core/Typography";
 import WarningIcon from "@material-ui/icons/Warning";
+import makeStyles from "@material-ui/core/styles/makeStyles";
 
-const CoordinatedEntry = () => (
-  <Container>
-    <Typography variant="h1" gutterBottom>
-      Coordinated Entry
-    </Typography>
+const useButtonStyles = makeStyles({
+  contained: {
+    "&, &:hover": {
+      background: colors.rosewood,
+    },
+  },
+});
 
-    <Typography paragraph>
-      All single homeless adults must go through the Coordinated Entry process
-      to receive services from Boulder County or the cities of Boulder or
-      Longmont. After meeting with a staff person and going through a short
-      screening, clients will be referred to the most appropriate service
-      depending on their needs.
-    </Typography>
-    <Card elevation={1} variant="outlined" square>
-      <List>
-        <ListItem>
-          <ListItemIcon>
-            <WarningIcon color="primary" fontSize="large" />
-          </ListItemIcon>
-          <ListItemText>
-            <Typography>
-              Note you must have been in Boulder County for 6 months before
-              applying. If you apply before 6 months, you will be barred from
-              any services.
-            </Typography>
-          </ListItemText>
-        </ListItem>
-      </List>
-    </Card>
-  </Container>
-);
+const CoordinatedEntry = () => {
+  const buttonClasses = useButtonStyles({});
+  return (
+    <Container>
+      <PageBanner color={colors.rosewood} text={"Coordinated Entry"} />
+      <Typography paragraph>
+        All single homeless adults must go through the Coordinated Entry process
+        to receive services from Boulder County or the cities of Boulder or
+        Longmont. After meeting with a staff person and going through a short
+        screening, clients will be referred to the most appropriate service
+        depending on their needs.
+      </Typography>
+      <Card variant="outlined" square>
+        <List>
+          <ListItem>
+            <ListItemIcon>
+              <WarningIcon color="primary" fontSize="large" />
+            </ListItemIcon>
+            <ListItemText>
+              <Typography>
+                Note you must have been in Boulder County for 6 months before
+                applying. If you apply before 6 months, you will be barred from
+                any services.
+              </Typography>
+            </ListItemText>
+          </ListItem>
+        </List>
+      </Card>
+      <Button
+        classes={buttonClasses}
+        fullWidth
+        href="https://www.bouldercounty.org/homeless/"
+        rel="noopener noreferrer"
+        startIcon={<ExitToAppIcon />}
+        size="large"
+        target="_blank"
+        variant="contained"
+      >
+        Coordinated Entry
+      </Button>
+    </Container>
+  );
+};
 
 export default CoordinatedEntry;

--- a/packages/upswyng-web/src/components/CoordinatedEntry.tsx
+++ b/packages/upswyng-web/src/components/CoordinatedEntry.tsx
@@ -36,13 +36,16 @@ const CoordinatedEntry = () => {
         <List>
           <ListItem>
             <ListItemIcon>
-              <WarningIcon color="primary" fontSize="large" />
+              <WarningIcon color="secondary" fontSize="large" />
             </ListItemIcon>
             <ListItemText>
-              <Typography>
+              <Typography paragraph>
                 Note you must have been in Boulder County for 6 months before
-                applying. If you apply before 6 months, you will be barred from
-                any services.
+                applying.
+              </Typography>
+              <Typography color="secondary">
+                If you apply before 6 months, you will be barred from any
+                services.
               </Typography>
             </ListItemText>
           </ListItem>

--- a/packages/upswyng-web/src/components/HomeButtons.tsx
+++ b/packages/upswyng-web/src/components/HomeButtons.tsx
@@ -103,13 +103,13 @@ const routerLinkButtons: THomeButtonRouterLink[] = [
   },
 ];
 
-const coordinatedEntryButton: THomeButtonAnchor = {
+const coordinatedEntryButton: THomeButtonRouterLink = {
   text: "Coordinated Entry",
-  href: "https://www.bouldercounty.org/homeless/",
   icon: DoorIcon,
+  linkProps: {
+    to: "/coordinated-entry",
+  },
   color: colors.rosewood,
-  target: "_blank",
-  rel: "noopener noreferrer",
 };
 
 const HomeButtonContainer = styled(Grid)`
@@ -132,7 +132,7 @@ const HomeButtons = () => (
       );
     })}{" "}
     <Grid item xs={12}>
-      <HomeAnchorLink
+      <HomeRouterLink
         {...coordinatedEntryButton}
         key={coordinatedEntryButton.text}
       >
@@ -140,7 +140,7 @@ const HomeButtons = () => (
           {coordinatedEntryButton.text}
           {coordinatedEntryButton.icon}
         </HomeButton>
-      </HomeAnchorLink>
+      </HomeRouterLink>
     </Grid>
   </>
 );

--- a/packages/upswyng-web/src/components/HomeButtons.tsx
+++ b/packages/upswyng-web/src/components/HomeButtons.tsx
@@ -11,12 +11,11 @@ import {
   SocksIcon,
   WifiIcon,
 } from "./Icons";
-import { HomeAnchorLink, HomeRouterLink } from "./HomeLink";
-import { THomeButtonAnchor, THomeButtonRouterLink } from "../webTypes";
-
 import { Grid } from "@material-ui/core";
 import HomeButton from "./HomeButton";
+import { HomeRouterLink } from "./HomeLink";
 import React from "react";
+import { THomeButtonRouterLink } from "../webTypes";
 import { colors } from "../App.styles";
 import styled from "styled-components";
 

--- a/packages/upswyng-web/src/components/HomeButtons.tsx
+++ b/packages/upswyng-web/src/components/HomeButtons.tsx
@@ -88,7 +88,7 @@ const routerLinkButtons: THomeButtonRouterLink[] = [
     text: "Job Training",
     icon: BusinessCenterIcon,
     linkProps: {
-      to: "/job_training",
+      to: "/job-training",
     },
     color: colors.lavendar,
   },

--- a/packages/upswyng-web/src/components/PageBanner.tsx
+++ b/packages/upswyng-web/src/components/PageBanner.tsx
@@ -15,6 +15,7 @@ const PageBannerContainer = styled.div`
   background: ${props => (props.color ? props.color : colors.greyMedium)};
   display: flex;
   flex-direction: row;
+  margin: 0 0 ${font.helpers.convertPixelsToRems(12)};
   padding: ${font.helpers.convertPixelsToRems(14)} 0;
   wrap: no-wrap;
 `;

--- a/packages/upswyng-web/src/theme/index.ts
+++ b/packages/upswyng-web/src/theme/index.ts
@@ -6,6 +6,9 @@ import typography from "./typography";
 const theme = createMuiTheme({
   palette,
   typography,
+  shape: {
+    borderRadius: 0,
+  },
 });
 
 export default theme;


### PR DESCRIPTION
This PR does not close an issue.

## What does this PR do?

- adds a "Coordinated Entry" landing page the user visits with important information
- updates the MUI theme shape to not have a border radius (keep'n things square)

![Coordinated Entry landing page](https://user-images.githubusercontent.com/6598084/73140069-07b3fc80-4032-11ea-832f-562a59ac6aff.png)

## How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![it's very important](https://media.giphy.com/media/24akSucLOFwwoZamdr/giphy.gif)
