### PR TITLE
[server] Temporarily store sessions in memory

### DIFF
--- a/packages/upswyng-server/src/app.ts
+++ b/packages/upswyng-server/src/app.ts
@@ -24,9 +24,9 @@ interface TAppOptions {
 }
 
 export default function(options: TAppOptions) {
-  const { dev, grantConfig, mongooseConnection, sessionSecret } = options;
-
-  const MongoStore = connectMongo(session);
+  const { dev, grantConfig, /* mongooseConnection,*/ sessionSecret } = options;
+  // TODO: Reenable database session once debugging is complete
+  // const MongoStore = connectMongo(session);
 
   return polka()
     .use(
@@ -38,9 +38,10 @@ export default function(options: TAppOptions) {
     )
     .use(
       session({
-        store: new MongoStore({ mongooseConnection }),
+        // TODO: Reenable database session once debugging is complete
+        // store: new MongoStore({ mongooseConnection }),
         secret: sessionSecret,
-        saveUninitialized: true,
+        saveUninitialized: false,
         resave: true,
       })
     )


### PR DESCRIPTION
Still troubleshooting the missing session problem. The database shows no sessions created at all. I'm thinking the Mongoose Connection may not yet be made when it's passed to the session middleware.