### PR TITLE
feat: add monthly schedule display

### DIFF
--- a/packages/upswyng-web/src/components/MonthlySchedule.tsx
+++ b/packages/upswyng-web/src/components/MonthlySchedule.tsx
@@ -5,7 +5,7 @@ import Typography from "@material-ui/core/Typography";
 
 const groupByRRuleText = (items: TScheduleItem[]) =>
   items.reduce(
-    (groupedItems: { [key: string]: TScheduleItem[] }, item: TScheduleItem) => {
+    (groupedItems: Record<string, TScheduleItem[]>, item: TScheduleItem) => {
       const currentKey = item.recurrenceRule.toText();
       const currentGroup = groupedItems[currentKey] || [];
       return {

--- a/packages/upswyng-web/src/components/MonthlySchedule.tsx
+++ b/packages/upswyng-web/src/components/MonthlySchedule.tsx
@@ -1,0 +1,70 @@
+import Grid from "@material-ui/core/Grid";
+import React from "react";
+import { TScheduleItem } from "@upswyng/upswyng-core";
+import Typography from "@material-ui/core/Typography";
+
+const groupByRRuleText = (items: TScheduleItem[]) =>
+  items.reduce(
+    (groupedItems: { [key: string]: TScheduleItem[] }, item: TScheduleItem) => {
+      const currentKey = item.recurrenceRule.toText();
+      const currentGroup = groupedItems[currentKey] || [];
+      return {
+        ...groupedItems,
+        [currentKey]: [...currentGroup, item],
+      };
+    },
+    {}
+  );
+
+const MonthlySchedule = ({ items }: { items: TScheduleItem[] }) => {
+  if (!items.length) {
+    return null;
+  }
+
+  const compareNextOpenDate = (item1: TScheduleItem, item2: TScheduleItem) =>
+    item1.recurrenceRule.all()[0].getTime() -
+    item2.recurrenceRule.all()[0].getTime();
+  const compareFromTime = (item1: TScheduleItem, item2: TScheduleItem) =>
+    parseInt(item1.fromTime.value) - parseInt(item2.fromTime.value);
+  const sortedMonthlyItems = items.sort(
+    (item1, item2) =>
+      compareNextOpenDate(item1, item2) || compareFromTime(item1, item2)
+  );
+
+  const groupedMonthlyItems = groupByRRuleText(sortedMonthlyItems);
+
+  return (
+    <Grid container spacing={3}>
+      {Object.entries(groupedMonthlyItems).map(([rRuleText, items]) => {
+        if (!items.length) {
+          return null;
+        }
+
+        const nextOccurenceDate = items[0].recurrenceRule
+          .all()[0]
+          .toLocaleString(undefined, { month: "short", day: "numeric" });
+        return (
+          <Grid item xs={12} key={rRuleText}>
+            <Grid container spacing={6}>
+              <Grid item xs={6}>
+                <Typography component="h3">{nextOccurenceDate}</Typography>
+                <Typography variant="caption">repeats {rRuleText}</Typography>
+              </Grid>
+              <Grid item xs={6}>
+                {items.map(item => (
+                  <Typography
+                    key={`${item.fromTime.value}${item.toTime.value}`}
+                  >
+                    {item.fromTime.label} - {item.toTime.label}
+                  </Typography>
+                ))}
+              </Grid>
+            </Grid>
+          </Grid>
+        );
+      })}
+    </Grid>
+  );
+};
+
+export default MonthlySchedule;

--- a/packages/upswyng-web/src/components/Resource.tsx
+++ b/packages/upswyng-web/src/components/Resource.tsx
@@ -132,17 +132,19 @@ export const Resource = () => {
             </ListItemText>
           </ListItem>
         )}
-        <ListItem component="div">
-          <ListItemIcon classes={listIconClasses}>
-            <ScheduleIcon />
-          </ListItemIcon>
-          <ListItemText>
-            <Typography component="h2" variant="srOnly">
-              Schedule
-            </Typography>
-            <Schedule schedule={resource.schedule} />
-          </ListItemText>
-        </ListItem>
+        {!!resource.schedule._items.length && (
+          <ListItem component="div">
+            <ListItemIcon classes={listIconClasses}>
+              <ScheduleIcon />
+            </ListItemIcon>
+            <ListItemText>
+              <Typography component="h2" variant="srOnly">
+                Schedule
+              </Typography>
+              <Schedule schedule={resource.schedule} />
+            </ListItemText>
+          </ListItem>
+        )}
         <ListItem component="div">
           <Typography variant="srOnly">Services</Typography>
           <Services resource={resource} />

--- a/packages/upswyng-web/src/components/Schedule.tsx
+++ b/packages/upswyng-web/src/components/Schedule.tsx
@@ -1,4 +1,5 @@
 import { ResourceSchedule, TScheduleItem } from "@upswyng/upswyng-core";
+import Divider from "@material-ui/core/Divider";
 import Grid from "@material-ui/core/Grid";
 import { RRule } from "rrule";
 import React from "react";
@@ -58,7 +59,7 @@ const MonthlySchedule = ({ items }: { items: TScheduleItem[] }) => {
   const groupedMonthlyItems = groupByRRuleText(sortedMonthlyItems);
 
   return (
-    <Grid container justify="space-between" spacing={5}>
+    <Grid container spacing={3}>
       {Object.entries(groupedMonthlyItems).map(([rRuleText, items]) => {
         if (!items.length) {
           return null;
@@ -68,19 +69,23 @@ const MonthlySchedule = ({ items }: { items: TScheduleItem[] }) => {
           .all()[0]
           .toLocaleString(undefined, { month: "short", day: "numeric" });
         return (
-          <React.Fragment key={rRuleText}>
-            <Grid item xs={5}>
-              <Typography component="h3">{nextOccurenceDate}</Typography>
-              <Typography variant="caption">repeats {rRuleText}</Typography>
+          <Grid item xs={12} key={rRuleText}>
+            <Grid container spacing={6}>
+              <Grid item xs={6}>
+                <Typography component="h3">{nextOccurenceDate}</Typography>
+                <Typography variant="caption">repeats {rRuleText}</Typography>
+              </Grid>
+              <Grid item xs={6}>
+                {items.map(item => (
+                  <Typography
+                    key={`${item.fromTime.value}${item.toTime.value}`}
+                  >
+                    {item.fromTime.label} - {item.toTime.label}
+                  </Typography>
+                ))}
+              </Grid>
             </Grid>
-            <Grid item xs={6}>
-              {items.map(item => (
-                <Typography key={`${item.fromTime.value}${item.toTime.value}`}>
-                  {item.fromTime.label} - {item.toTime.label}
-                </Typography>
-              ))}
-            </Grid>
-          </React.Fragment>
+          </Grid>
         );
       })}
     </Grid>
@@ -102,24 +107,26 @@ const WeeklySchedule = ({ items }: { items: TScheduleItem[] }) => {
   });
 
   return (
-    <Grid container>
+    <Grid container spacing={1}>
       {dayItemsMap
         .filter(x => x.items.length)
         .map(x => (
-          <React.Fragment key={x.day}>
-            <Grid item xs={4}>
-              <Typography component="h3" variant="subtitle2">
-                {capitalize(x.day)}:
-              </Typography>
-            </Grid>
-            <Grid item xs={8}>
-              {x.items.map(i => (
-                <Typography key={`${i.fromTime.value}${i.toTime.value}`}>
-                  {i.fromTime.label} - {i.toTime.label}
+          <Grid item xs={12} key={x.day}>
+            <Grid container spacing={6}>
+              <Grid item xs={6}>
+                <Typography component="h3" variant="subtitle2">
+                  {capitalize(x.day)}:
                 </Typography>
-              ))}
+              </Grid>
+              <Grid item xs={6}>
+                {x.items.map(i => (
+                  <Typography key={`${i.fromTime.value}${i.toTime.value}`}>
+                    {i.fromTime.label} - {i.toTime.label}
+                  </Typography>
+                ))}
+              </Grid>
             </Grid>
-          </React.Fragment>
+          </Grid>
         ))}
     </Grid>
   );
@@ -144,15 +151,22 @@ const Schedule = ({ schedule }: ScheduleProps) => {
     }, {} as Record<keyof typeof days, TScheduleItem[]>);
 
     return (
-      <>
+      <Grid container direction="column" spacing={5} wrap="nowrap">
         {Object.entries(commentMap).map(([comment, items]) => (
           <React.Fragment key={comment}>
-            <WeeklySchedule items={items as TScheduleItem[]} />
-            <MonthlySchedule items={items as TScheduleItem[]} />
+            <Grid item>
+              <WeeklySchedule items={items as TScheduleItem[]} />
+            </Grid>
+            <Grid item>
+              <Divider />
+            </Grid>
+            <Grid item>
+              <MonthlySchedule items={items as TScheduleItem[]} />
+            </Grid>
             {comment !== "_no_comment_" && <div>{comment}</div>}
           </React.Fragment>
         ))}
-      </>
+      </Grid>
     );
   } catch {
     return null;

--- a/packages/upswyng-web/src/components/Schedule.tsx
+++ b/packages/upswyng-web/src/components/Schedule.tsx
@@ -38,11 +38,7 @@ const groupByRRuleText = (items: TScheduleItem[]) =>
   );
 
 const MonthlySchedule = ({ items }: { items: TScheduleItem[] }) => {
-  const monthlyItems = items.filter(
-    (item: TScheduleItem) => item.recurrenceRule.options.freq === RRule.MONTHLY
-  );
-
-  if (!monthlyItems.length) {
+  if (!items.length) {
     return null;
   }
 
@@ -96,12 +92,10 @@ const WeeklySchedule = ({ items }: { items: TScheduleItem[] }) => {
   const dayItemsMap = Object.entries(days).map(([label, key]) => {
     return {
       day: label,
-      items: items.filter(
-        item =>
-          item.recurrenceRule.options.freq === RRule.WEEKLY &&
-          item.recurrenceRule.options.byweekday.includes(
-            (RRule as any)[key]["weekday"]
-          )
+      items: items.filter(item =>
+        item.recurrenceRule.options.byweekday.includes(
+          (RRule as any)[key]["weekday"]
+        )
       ),
     };
   });
@@ -152,20 +146,34 @@ const Schedule = ({ schedule }: ScheduleProps) => {
 
     return (
       <Grid container direction="column" spacing={5} wrap="nowrap">
-        {Object.entries(commentMap).map(([comment, items]) => (
-          <React.Fragment key={comment}>
-            <Grid item>
-              <WeeklySchedule items={items as TScheduleItem[]} />
-            </Grid>
-            <Grid item>
-              <Divider />
-            </Grid>
-            <Grid item>
-              <MonthlySchedule items={items as TScheduleItem[]} />
-            </Grid>
-            {comment !== "_no_comment_" && <div>{comment}</div>}
-          </React.Fragment>
-        ))}
+        {Object.entries(commentMap).map(([comment, items]) => {
+          const weeklyItems = items.filter(
+            item => item.recurrenceRule.options.freq === RRule.WEEKLY
+          ) as TScheduleItem[];
+          const monthlyItems = items.filter(
+            item => item.recurrenceRule.options.freq === RRule.MONTHLY
+          ) as TScheduleItem[];
+          return (
+            <React.Fragment key={comment}>
+              {!!weeklyItems.length && (
+                <Grid item>
+                  <WeeklySchedule items={weeklyItems} />
+                </Grid>
+              )}
+              {!!weeklyItems.length && !!monthlyItems.length && (
+                <Grid item>
+                  <Divider />
+                </Grid>
+              )}
+              {!!monthlyItems.length && (
+                <Grid item>
+                  <MonthlySchedule items={monthlyItems} />
+                </Grid>
+              )}
+              {comment !== "_no_comment_" && <div>{comment}</div>}
+            </React.Fragment>
+          );
+        })}
       </Grid>
     );
   } catch {

--- a/packages/upswyng-web/src/components/Schedule.tsx
+++ b/packages/upswyng-web/src/components/Schedule.tsx
@@ -1,130 +1,15 @@
 import { ResourceSchedule, TScheduleItem } from "@upswyng/upswyng-core";
+import WeeklySchedule, { days } from "./WeeklySchedule";
 import Divider from "@material-ui/core/Divider";
 import Grid from "@material-ui/core/Grid";
+import MonthlySchedule from "./MonthlySchedule";
 import { RRule } from "rrule";
 import React from "react";
 import { TResourceScheduleData } from "@upswyng/upswyng-types";
-import Typography from "@material-ui/core/Typography";
 
 interface ScheduleProps {
   schedule: TResourceScheduleData;
 }
-
-const days = {
-  sunday: "SU",
-  monday: "MO",
-  tuesday: "TU",
-  wednesday: "WE",
-  thursday: "TH",
-  friday: "FR",
-  saturday: "SA",
-};
-
-function capitalize(x: string): string {
-  return x.charAt(0).toUpperCase() + x.slice(1);
-}
-
-const groupByRRuleText = (items: TScheduleItem[]) =>
-  items.reduce(
-    (groupedItems: { [key: string]: TScheduleItem[] }, item: TScheduleItem) => {
-      const currentKey = item.recurrenceRule.toText();
-      const currentGroup = groupedItems[currentKey] || [];
-      return {
-        ...groupedItems,
-        [currentKey]: [...currentGroup, item],
-      };
-    },
-    {}
-  );
-
-const MonthlySchedule = ({ items }: { items: TScheduleItem[] }) => {
-  if (!items.length) {
-    return null;
-  }
-
-  const compareNextOpenDate = (item1: TScheduleItem, item2: TScheduleItem) =>
-    item1.recurrenceRule.all()[0].getTime() -
-    item2.recurrenceRule.all()[0].getTime();
-  const compareFromTime = (item1: TScheduleItem, item2: TScheduleItem) =>
-    parseInt(item1.fromTime.value) - parseInt(item2.fromTime.value);
-  const sortedMonthlyItems = items.sort(
-    (item1, item2) =>
-      compareNextOpenDate(item1, item2) || compareFromTime(item1, item2)
-  );
-
-  const groupedMonthlyItems = groupByRRuleText(sortedMonthlyItems);
-
-  return (
-    <Grid container spacing={3}>
-      {Object.entries(groupedMonthlyItems).map(([rRuleText, items]) => {
-        if (!items.length) {
-          return null;
-        }
-
-        const nextOccurenceDate = items[0].recurrenceRule
-          .all()[0]
-          .toLocaleString(undefined, { month: "short", day: "numeric" });
-        return (
-          <Grid item xs={12} key={rRuleText}>
-            <Grid container spacing={6}>
-              <Grid item xs={6}>
-                <Typography component="h3">{nextOccurenceDate}</Typography>
-                <Typography variant="caption">repeats {rRuleText}</Typography>
-              </Grid>
-              <Grid item xs={6}>
-                {items.map(item => (
-                  <Typography
-                    key={`${item.fromTime.value}${item.toTime.value}`}
-                  >
-                    {item.fromTime.label} - {item.toTime.label}
-                  </Typography>
-                ))}
-              </Grid>
-            </Grid>
-          </Grid>
-        );
-      })}
-    </Grid>
-  );
-};
-
-const WeeklySchedule = ({ items }: { items: TScheduleItem[] }) => {
-  const dayItemsMap = Object.entries(days).map(([label, key]) => {
-    return {
-      day: label,
-      items: items.filter(item =>
-        item.recurrenceRule.options.byweekday.includes(
-          (RRule as any)[key]["weekday"]
-        )
-      ),
-    };
-  });
-
-  return (
-    <Grid container spacing={1}>
-      {dayItemsMap
-        .filter(x => x.items.length)
-        .map(x => (
-          <Grid item xs={12} key={x.day}>
-            <Grid container spacing={6}>
-              <Grid item xs={6}>
-                <Typography component="h3" variant="subtitle2">
-                  {capitalize(x.day)}:
-                </Typography>
-              </Grid>
-              <Grid item xs={6}>
-                {x.items.map(i => (
-                  <Typography key={`${i.fromTime.value}${i.toTime.value}`}>
-                    {i.fromTime.label} - {i.toTime.label}
-                  </Typography>
-                ))}
-              </Grid>
-            </Grid>
-          </Grid>
-        ))}
-    </Grid>
-  );
-};
 
 const Schedule = ({ schedule }: ScheduleProps) => {
   try {

--- a/packages/upswyng-web/src/components/Schedule.tsx
+++ b/packages/upswyng-web/src/components/Schedule.tsx
@@ -85,17 +85,6 @@ const MonthlySchedule = ({ items }: { items: TScheduleItem[] }) => {
       })}
     </Grid>
   );
-
-  // return (
-  //   <>
-  //     {Object.entries(monthItemsMap).map(([rRuleText, items]) => (
-  //       <div key={rRuleText}>
-  //         <div>{rRuleText}</div>
-  //         {items.map(item => `${item.fromTime.label} - ${item.toTime.label}`)}
-  //       </div>
-  //     ))}
-  //   </>
-  // );
 };
 
 const WeeklySchedule = ({ items }: { items: TScheduleItem[] }) => {
@@ -158,7 +147,7 @@ const Schedule = ({ schedule }: ScheduleProps) => {
       <>
         {Object.entries(commentMap).map(([comment, items]) => (
           <div key={comment}>
-            {/* <WeeklySchedule items={items as TScheduleItem[]} />*/}
+            <WeeklySchedule items={items as TScheduleItem[]} />
             <MonthlySchedule items={items as TScheduleItem[]} />
             {comment !== "_no_comment_" && <div>{comment}</div>}
           </div>

--- a/packages/upswyng-web/src/components/Schedule.tsx
+++ b/packages/upswyng-web/src/components/Schedule.tsx
@@ -102,11 +102,11 @@ const WeeklySchedule = ({ items }: { items: TScheduleItem[] }) => {
   });
 
   return (
-    <div>
+    <Grid container>
       {dayItemsMap
         .filter(x => x.items.length)
         .map(x => (
-          <Grid container key={x.day}>
+          <React.Fragment key={x.day}>
             <Grid item xs={4}>
               <Typography component="h3" variant="subtitle2">
                 {capitalize(x.day)}:
@@ -119,9 +119,9 @@ const WeeklySchedule = ({ items }: { items: TScheduleItem[] }) => {
                 </Typography>
               ))}
             </Grid>
-          </Grid>
+          </React.Fragment>
         ))}
-    </div>
+    </Grid>
   );
 };
 
@@ -146,11 +146,11 @@ const Schedule = ({ schedule }: ScheduleProps) => {
     return (
       <>
         {Object.entries(commentMap).map(([comment, items]) => (
-          <div key={comment}>
+          <React.Fragment key={comment}>
             <WeeklySchedule items={items as TScheduleItem[]} />
             <MonthlySchedule items={items as TScheduleItem[]} />
             {comment !== "_no_comment_" && <div>{comment}</div>}
-          </div>
+          </React.Fragment>
         ))}
       </>
     );

--- a/packages/upswyng-web/src/components/WeeklySchedule.tsx
+++ b/packages/upswyng-web/src/components/WeeklySchedule.tsx
@@ -1,0 +1,59 @@
+import Grid from "@material-ui/core/Grid";
+import { RRule } from "rrule";
+import React from "react";
+import { TScheduleItem } from "@upswyng/upswyng-core";
+import Typography from "@material-ui/core/Typography";
+
+export const days = {
+  sunday: "SU",
+  monday: "MO",
+  tuesday: "TU",
+  wednesday: "WE",
+  thursday: "TH",
+  friday: "FR",
+  saturday: "SA",
+};
+
+function capitalize(x: string): string {
+  return x.charAt(0).toUpperCase() + x.slice(1);
+}
+
+const WeeklySchedule = ({ items }: { items: TScheduleItem[] }) => {
+  const dayItemsMap = Object.entries(days).map(([label, key]) => {
+    return {
+      day: label,
+      items: items.filter(item =>
+        item.recurrenceRule.options.byweekday.includes(
+          (RRule as any)[key]["weekday"]
+        )
+      ),
+    };
+  });
+
+  return (
+    <Grid container spacing={1}>
+      {dayItemsMap
+        .filter(x => x.items.length)
+        .map(x => (
+          <Grid item xs={12} key={x.day}>
+            <Grid container spacing={6}>
+              <Grid item xs={6}>
+                <Typography component="h3" variant="subtitle2">
+                  {capitalize(x.day)}:
+                </Typography>
+              </Grid>
+              <Grid item xs={6}>
+                {x.items.map(i => (
+                  <Typography key={`${i.fromTime.value}${i.toTime.value}`}>
+                    {i.fromTime.label} - {i.toTime.label}
+                  </Typography>
+                ))}
+              </Grid>
+            </Grid>
+          </Grid>
+        ))}
+    </Grid>
+  );
+};
+
+export default WeeklySchedule;

--- a/packages/upswyng-web/src/theme/index.ts
+++ b/packages/upswyng-web/src/theme/index.ts
@@ -25,6 +25,7 @@ const palette = {
   action: {
     active: "#fff",
   },
+  divider: "#fff",
 };
 
 const typography = {

--- a/packages/upswyng-web/src/theme/index.ts
+++ b/packages/upswyng-web/src/theme/index.ts
@@ -52,6 +52,11 @@ const typography = {
     fontWeight: 400,
     margin: 0,
   },
+  caption: {
+    display: "inline-block",
+    fontSize: "0.75rem",
+    lineHeight: 1.3,
+  },
 } as { [name: string]: React.CSSProperties };
 
 const theme = createMuiTheme({


### PR DESCRIPTION
This PR does not close an issue.

## What does this PR do?

Adds a custom display for monthly schedules.

### Examples

_individual monthly schedule display example_
<img width="439" alt="Screen Shot 2020-01-29 at 6 38 53 PM" src="https://user-images.githubusercontent.com/6598084/73412720-c8520e00-42c6-11ea-92c9-4f0692faf9eb.png">

_example with a weekly and monthly schedule combination_
<img width="450" alt="Screen Shot 2020-01-29 at 6 39 31 PM" src="https://user-images.githubusercontent.com/6598084/73412723-c9833b00-42c6-11ea-907e-3073b23582ef.png">

## How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/cApRuznZiLJo246DmE/giphy.gif)
