### PR TITLE
fix: update date comparison to use UTC

### DIFF
--- a/packages/upswyng-core/src/ResourceSchedule.ts
+++ b/packages/upswyng-core/src/ResourceSchedule.ts
@@ -54,7 +54,9 @@ function validateTimezone(timezone: string): TTimezoneName {
 
 function makeSchedulePeriodDate(dt: Date, timeValue: string): Date {
   const dateFormat = "YYYY MM DD";
-  const itemDate = moment(dt).format(dateFormat);
+  const itemDate = moment(dt)
+    .utc()
+    .format(dateFormat);
 
   const dateTimeFormat = `${dateFormat} H:mm A`;
   return moment(`${itemDate.toString()} ${timeValue}`, dateTimeFormat).toDate();


### PR DESCRIPTION
This PR does not close an issue.

## What does this PR do?

- updates the date compared against RRule instances to be UTC, as RRule expects

This fixes the displaying of "next open at" in the web app and fixes the tests associated with this logic in core.

## How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![internal screaming](https://media.giphy.com/media/3o7bu9UwnixfwsBiZq/giphy.gif)
