### PR TITLE
🧼 add "not found" component

### DIFF
--- a/packages/upswyng-web/src/App.tsx
+++ b/packages/upswyng-web/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { Route, BrowserRouter as Router } from "react-router-dom";
+import { Route, BrowserRouter as Router, Switch } from "react-router-dom";
 
 import About from "./components/About";
 import { BannerColorContextProvider } from "./components/BannerColorContext";
@@ -10,6 +10,7 @@ import Header from "./components/Header";
 import Home from "./components/Home";
 import Hotlines from "./components/Hotlines";
 import { LastLocationProvider } from "react-router-last-location";
+import NotFound from "./components/NotFound";
 import PrivacyPolicy from "./components/PrivacyPolicy";
 import ReportIssue from "./components/ReportIssue";
 import Resource from "./components/Resource";
@@ -39,28 +40,35 @@ class App extends Component {
           <LastLocationProvider>
             <BannerColorContextProvider>
               <Header />
-              <Route exact path="/" component={Home} />
-              <Route exact path="/about" component={About} />
-              <Route path="/coordinated-entry" component={CoordinatedEntry} />
-              <Route path="/shelters" component={Shelters} />
-              <Route path="/job-training" component={JobTraining} />
-              <Route path="/health" component={Health} />
-              <Route path="/hygiene" component={Hygiene} />
-              <Route exact path="/hotlines" component={Hotlines} />
-              <Route path="/food" component={Food} />
-              <Route exact path="/privacy-policy" component={PrivacyPolicy} />
-              <Route path="/transit" component={Transit} />
-              <Route exact path="/resource/:resourceId" component={Resource} />
-              <Route path="/resources" component={Resources} />
-              <Route path="/social_services" component={SocialServices} />
-              <Route exact path="/search" component={Search} />
-              <Route exact path="/terms-of-use" component={TermsOfUse} />
-              <Route path="/wifi" component={Wifi} />
-              <Route
-                exact
-                path="/report-issue/:resourceId"
-                component={ReportIssue}
-              />
+              <Switch>
+                <Route exact path="/" component={Home} />
+                <Route exact path="/about" component={About} />
+                <Route path="/coordinated-entry" component={CoordinatedEntry} />
+                <Route path="/shelters" component={Shelters} />
+                <Route path="/job-training" component={JobTraining} />
+                <Route path="/health" component={Health} />
+                <Route path="/hygiene" component={Hygiene} />
+                <Route exact path="/hotlines" component={Hotlines} />
+                <Route path="/food" component={Food} />
+                <Route exact path="/privacy-policy" component={PrivacyPolicy} />
+                <Route path="/transit" component={Transit} />
+                <Route
+                  exact
+                  path="/resource/:resourceId"
+                  component={Resource}
+                />
+                <Route path="/resources" component={Resources} />
+                <Route path="/social_services" component={SocialServices} />
+                <Route exact path="/search" component={Search} />
+                <Route exact path="/terms-of-use" component={TermsOfUse} />
+                <Route path="/wifi" component={Wifi} />
+                <Route
+                  exact
+                  path="/report-issue/:resourceId"
+                  component={ReportIssue}
+                />
+                <Route component={NotFound} />
+              </Switch>
             </BannerColorContextProvider>
           </LastLocationProvider>
         </Router>

--- a/packages/upswyng-web/src/components/NotFound.tsx
+++ b/packages/upswyng-web/src/components/NotFound.tsx
@@ -1,0 +1,42 @@
+import Container from "@material-ui/core/Container";
+import MuiLink from "@material-ui/core/Link";
+import PageBanner from "./PageBanner";
+import React from "react";
+import { Link as RouterLink } from "react-router-dom";
+import SearchForm from "./SearchForm";
+import Typography from "@material-ui/core/Typography";
+import { colors } from "../App.styles";
+import createStyles from "@material-ui/core/styles/createStyles";
+import makeStyles from "@material-ui/core/styles/makeStyles";
+
+const useStyles = makeStyles(() =>
+  createStyles({
+    marginTop: {
+      marginTop: "3.5rem",
+    },
+  })
+);
+
+const NotFound = () => {
+  const classes = useStyles();
+  return (
+    <Container>
+      <PageBanner color={colors.orangeDark} text={"Page not Found"} />
+      <Typography variant="h3">
+        Whoops! We&apos;re having trouble finding that page.
+      </Typography>
+      <div className={classes.marginTop}>
+        <SearchForm />
+      </div>
+      <Typography className={classes.marginTop}>
+        You can also go back{" "}
+        <MuiLink component={RouterLink} to="/">
+          home
+        </MuiLink>{" "}
+        to browse.
+      </Typography>
+    </Container>
+  );
+};
+
+export default NotFound;

--- a/packages/upswyng-web/src/components/NotFound.tsx
+++ b/packages/upswyng-web/src/components/NotFound.tsx
@@ -1,4 +1,5 @@
 import Container from "@material-ui/core/Container";
+import { Grid } from "@material-ui/core";
 import MuiLink from "@material-ui/core/Link";
 import PageBanner from "./PageBanner";
 import React from "react";
@@ -6,37 +7,30 @@ import { Link as RouterLink } from "react-router-dom";
 import SearchForm from "./SearchForm";
 import Typography from "@material-ui/core/Typography";
 import { colors } from "../App.styles";
-import createStyles from "@material-ui/core/styles/createStyles";
-import makeStyles from "@material-ui/core/styles/makeStyles";
 
-const useStyles = makeStyles(() =>
-  createStyles({
-    marginTop: {
-      marginTop: "3.5rem",
-    },
-  })
-);
-
-const NotFound = () => {
-  const classes = useStyles();
-  return (
-    <Container>
-      <PageBanner color={colors.orangeDark} text={"Page not Found"} />
-      <Typography variant="h3">
-        Whoops! We&apos;re having trouble finding that page.
-      </Typography>
-      <div className={classes.marginTop}>
+const NotFound = () => (
+  <Container>
+    <PageBanner color={colors.orangeDark} text={"Page not Found"} />
+    <Grid container direction="column" spacing={4}>
+      <Grid item>
+        <Typography component="p" variant="h3">
+          Whoops! We&apos;re having trouble finding that page.
+        </Typography>
+      </Grid>
+      <Grid item>
         <SearchForm />
-      </div>
-      <Typography className={classes.marginTop}>
-        You can also go back{" "}
-        <MuiLink component={RouterLink} to="/">
-          home
-        </MuiLink>{" "}
-        to browse.
-      </Typography>
-    </Container>
-  );
-};
+      </Grid>
+      <Grid item>
+        <Typography>
+          You can also go back{" "}
+          <MuiLink component={RouterLink} to="/">
+            home
+          </MuiLink>{" "}
+          to browse.
+        </Typography>
+      </Grid>
+    </Grid>
+  </Container>
+);
 
 export default NotFound;


### PR DESCRIPTION
This PR closes #290

## What does this PR do?

Adds a "not found" component that renders whenever a faulty URL is entered.

<img width="496" alt="Screen Shot 2020-03-26 at 10 48 43 PM" src="https://user-images.githubusercontent.com/51095001/77723031-e5e4e080-6fb4-11ea-80aa-4ae3fd61125f.png">


## How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/1bAdvIjqaXCSc/giphy.gif)
