### PR TITLE
✨ [server] Add job kind and ID copy button to Job display

### DIFF
--- a/packages/upswyng-server/src/components/Job.svelte
+++ b/packages/upswyng-server/src/components/Job.svelte
@@ -144,7 +144,7 @@
     </div>
   </div>
   <div class="job-kind">
-    <p class="is-size-8">
+    <p>
       <span
         class="is-size-9 has-text-weight-semibold has-text-grey is-capitalized">
         {job.data.kind.replace(/_/g, ' ')}

--- a/packages/upswyng-server/src/components/Job.svelte
+++ b/packages/upswyng-server/src/components/Job.svelte
@@ -2,6 +2,7 @@
   import { createEventDispatcher } from "svelte";
   import { onMount, onDestroy } from "svelte";
   import converter from "number-to-words-en";
+  import CopyToClipboard from "./CopyToClipboard.svelte";
   import jsonHighlight from "json-highlight";
   import prettyMilliseconds from "pretty-ms";
 
@@ -154,6 +155,7 @@
     <p class="is-size-8">
       <span class="has-text-weight-semibold">ID:</span>
       <span class="is-size-9">{job.id}</span>
+      <CopyToClipboard textToCopy={job.id} />
     </p>
   </div>
   {#if job.attemptsMade && job.status !== 'completed'}

--- a/packages/upswyng-server/src/components/Job.svelte
+++ b/packages/upswyng-server/src/components/Job.svelte
@@ -154,7 +154,7 @@
   <div class="job-id">
     <p class="is-size-8">
       <span class="has-text-weight-semibold">ID:</span>
-      <span class="is-size-9">{job.id}</span>
+      <span class="is-size-9 is-family-monospace">{job.id}</span>
       <CopyToClipboard textToCopy={job.id} />
     </p>
   </div>

--- a/packages/upswyng-server/src/components/Job.svelte
+++ b/packages/upswyng-server/src/components/Job.svelte
@@ -142,6 +142,14 @@
       {/if}
     </div>
   </div>
+  <div class="job-kind">
+    <p class="is-size-8">
+      <span
+        class="is-size-9 has-text-weight-semibold has-text-grey is-capitalized">
+        {job.data.kind.replace(/_/g, ' ')}
+      </span>
+    </p>
+  </div>
   <div class="job-id">
     <p class="is-size-8">
       <span class="has-text-weight-semibold">ID:</span>


### PR DESCRIPTION
- Add `kind` to top-level display so user doesn't have to open details to see what kind of job they're looking at
- Make the job ID monospace for consistency with the rest of the UI
- Add button to copy the job ID to the clipboard

<img width="358" alt="Screen Shot 2020-03-29 at 9 31 47 AM" src="https://user-images.githubusercontent.com/5778036/77853245-716e9500-71a0-11ea-8d29-4ce0b92d18c1.png">
