### PR TITLE
feat: edit displayed sub-categories in public app

### DIFF
--- a/packages/upswyng-server/src/data-pipeline/setupCategories.ts
+++ b/packages/upswyng-server/src/data-pipeline/setupCategories.ts
@@ -103,7 +103,7 @@ const categories: {
     name: "Transit",
     stub: "transit",
     subcategories: [
-      { name: "Bus Passes", stub: "bus" },
+      { name: "Bus Passes", stub: "bus_passes" },
       { name: "Bicycle", stub: "bicycle" },
     ],
   },

--- a/packages/upswyng-server/src/data-pipeline/setupCategories.ts
+++ b/packages/upswyng-server/src/data-pipeline/setupCategories.ts
@@ -55,7 +55,6 @@ const categories: {
     subcategories: [
       { name: "Craigs List", stub: "craigslist" },
       { name: "Temp Agency", stub: "temp_agency" },
-      { name: "Day Labor", stub: "day_labor" },
       { name: "Ready to Work", stub: "ready_to_work" },
       { name: "Career Counseling", stub: "career_counseling" },
     ],
@@ -104,9 +103,8 @@ const categories: {
     name: "Transit",
     stub: "transit",
     subcategories: [
-      { name: "Bus", stub: "bus" },
+      { name: "Bus Passes", stub: "bus" },
       { name: "Bicycle", stub: "bicycle" },
-      { name: "Lite Rail", stub: "lite_rail" },
     ],
   },
   {

--- a/packages/upswyng-web/src/components/Categories.tsx
+++ b/packages/upswyng-web/src/components/Categories.tsx
@@ -259,7 +259,7 @@ export const categories: Record<TCategoryName, TCategoryDefinition> = {
     },
     subCategories: [
       {
-        text: "Bus",
+        text: "Bus Passes",
         stub: "bus",
       },
       {

--- a/packages/upswyng-web/src/components/Categories.tsx
+++ b/packages/upswyng-web/src/components/Categories.tsx
@@ -139,10 +139,6 @@ export const categories: Record<TCategoryName, TCategoryDefinition> = {
         stub: "temp_agency",
       },
       {
-        text: "Day Labor",
-        stub: "day_labor",
-      },
-      {
         text: "Career Counseling",
         stub: "career_counseling",
       },

--- a/packages/upswyng-web/src/components/Categories.tsx
+++ b/packages/upswyng-web/src/components/Categories.tsx
@@ -266,10 +266,6 @@ export const categories: Record<TCategoryName, TCategoryDefinition> = {
         text: "Bicycle",
         stub: "bicycle",
       },
-      {
-        text: "Lite Rail",
-        stub: "lite_rail",
-      },
     ],
   },
   Wifi: {

--- a/packages/upswyng-web/src/components/Categories.tsx
+++ b/packages/upswyng-web/src/components/Categories.tsx
@@ -256,7 +256,7 @@ export const categories: Record<TCategoryName, TCategoryDefinition> = {
     subCategories: [
       {
         text: "Bus Passes",
-        stub: "bus",
+        stub: "bus_passes",
       },
       {
         text: "Bicycle",


### PR DESCRIPTION
This PR does not close an issue

## What does this PR do?

- removes "Lite Rail" sub-category from displaying in public-facing app, since our initial launch will target Boulder County
- removes "Day Labor" sub-category from displaying in public-facing app, since it is redundant with "Ready to Work" in Boulder County
- updates the displayed name for the "Bus" category to "Bus Passes"

## How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![tidy up](https://media.giphy.com/media/9PtfS5tTC8ejlYfCLU/giphy.gif)
