### PR TITLE
update resource list layout

### DIFF
--- a/packages/upswyng-core/src/index.ts
+++ b/packages/upswyng-core/src/index.ts
@@ -1,8 +1,5 @@
-import ResourceSchedule_ from "./ResourceSchedule";
 import { TScheduleItem as TScheduleItem_ } from "./ResourceSchedule";
-import Time_ from "./Time";
 
-export const ResourceSchedule = ResourceSchedule_;
-export const Time = Time_;
-
+export { default as ResourceSchedule } from "./ResourceSchedule";
+export { default as Time } from "./Time";
 export type TScheduleItem = TScheduleItem_;

--- a/packages/upswyng-web/src/components/MenuDrawer.tsx
+++ b/packages/upswyng-web/src/components/MenuDrawer.tsx
@@ -11,66 +11,81 @@ import ListItemText from "@material-ui/core/ListItemText";
 import Logo from "./Logo";
 import React from "react";
 import { Link as RouterLink } from "react-router-dom";
+import { Theme } from "@material-ui/core/styles/createMuiTheme";
 import Typography from "@material-ui/core/Typography";
+import makeStyles from "@material-ui/styles/makeStyles";
+
+const useStyles = makeStyles((theme: Theme) => ({
+  drawerPaper: {
+    background: theme.palette.background.default,
+  },
+}));
 
 interface MenuDrawerProps {
   handleMenuClose: Function;
   open: boolean;
 }
 
-const MenuDrawer = ({ handleMenuClose, open }: MenuDrawerProps) => (
-  <Drawer onClose={() => handleMenuClose()} open={open}>
-    <Grid container direction="column">
-      <Grid container item justify="flex-end">
-        <IconButton onClick={() => handleMenuClose()}>
-          <Typography variant="srOnly">close menu</Typography>
-          {CloseIcon}
-        </IconButton>
+const MenuDrawer = ({ handleMenuClose, open }: MenuDrawerProps) => {
+  const classes = useStyles();
+  return (
+    <Drawer
+      onClose={() => handleMenuClose()}
+      open={open}
+      PaperProps={{ className: classes.drawerPaper }}
+    >
+      <Grid container direction="column">
+        <Grid container item justify="flex-end">
+          <IconButton onClick={() => handleMenuClose()}>
+            <Typography variant="srOnly">close menu</Typography>
+            {CloseIcon}
+          </IconButton>
+        </Grid>
+        <Grid item>
+          <List disablePadding>
+            <ListItem
+              button
+              component={RouterLink}
+              onClick={() => handleMenuClose()}
+              to="/"
+            >
+              <Typography variant="srOnly">home</Typography>
+              <Box maxWidth="100%" width={250}>
+                <Logo />
+              </Box>
+            </ListItem>
+            <ListItem
+              button
+              component={RouterLink}
+              onClick={() => handleMenuClose()}
+              to="/about"
+            >
+              <ListItemIcon>{InfoIcon}</ListItemIcon>
+              <ListItemText>About</ListItemText>
+            </ListItem>
+            <ListItem
+              button
+              component={RouterLink}
+              onClick={() => handleMenuClose()}
+              to="/terms-of-use"
+            >
+              <ListItemIcon>{TermsOfServiceIcon}</ListItemIcon>
+              <ListItemText>Terms of Use</ListItemText>
+            </ListItem>
+            <ListItem
+              button
+              component={RouterLink}
+              onClick={() => handleMenuClose()}
+              to="/privacy-policy"
+            >
+              <ListItemIcon>{PolicyIcon}</ListItemIcon>
+              <ListItemText>Privacy policy</ListItemText>
+            </ListItem>
+          </List>
+        </Grid>
       </Grid>
-      <Grid item>
-        <List disablePadding>
-          <ListItem
-            button
-            component={RouterLink}
-            onClick={() => handleMenuClose()}
-            to="/"
-          >
-            <Typography variant="srOnly">home</Typography>
-            <Box maxWidth="100%" width={250}>
-              <Logo />
-            </Box>
-          </ListItem>
-          <ListItem
-            button
-            component={RouterLink}
-            onClick={() => handleMenuClose()}
-            to="/about"
-          >
-            <ListItemIcon>{InfoIcon}</ListItemIcon>
-            <ListItemText>About</ListItemText>
-          </ListItem>
-          <ListItem
-            button
-            component={RouterLink}
-            onClick={() => handleMenuClose()}
-            to="/terms-of-use"
-          >
-            <ListItemIcon>{TermsOfServiceIcon}</ListItemIcon>
-            <ListItemText>Terms of Use</ListItemText>
-          </ListItem>
-          <ListItem
-            button
-            component={RouterLink}
-            onClick={() => handleMenuClose()}
-            to="/privacy-policy"
-          >
-            <ListItemIcon>{PolicyIcon}</ListItemIcon>
-            <ListItemText>Privacy policy</ListItemText>
-          </ListItem>
-        </List>
-      </Grid>
-    </Grid>
-  </Drawer>
-);
+    </Drawer>
+  );
+};
 
 export default MenuDrawer;

--- a/packages/upswyng-web/src/components/ResourceCard.tsx
+++ b/packages/upswyng-web/src/components/ResourceCard.tsx
@@ -87,7 +87,7 @@ const ResourceCard = ({
   };
 
   return (
-    <Card raised>
+    <Card>
       <CardActionArea
         aria-describedby={scheduleText ? resourceScheduleId : undefined}
         role="link"

--- a/packages/upswyng-web/src/components/ResourceCard.tsx
+++ b/packages/upswyng-web/src/components/ResourceCard.tsx
@@ -82,6 +82,7 @@ const ResourceCard = ({
   });
   const history = useHistory();
   const resourceUrl = `/resource/${resourceId}`;
+  const resourceScheduleId = `${resourceId}-schedule`;
 
   const handleClick = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -90,7 +91,11 @@ const ResourceCard = ({
 
   return (
     <Card className={classes.card} raised>
-      <CardActionArea role="link" onClick={handleClick}>
+      <CardActionArea
+        aria-describedby={scheduleText && resourceScheduleId}
+        role="link"
+        onClick={handleClick}
+      >
         <CardMedia
           component={() =>
             resourceImage ? (
@@ -113,12 +118,14 @@ const ResourceCard = ({
         <CardContent>
           <Typography variant="subtitle1">{resourceName}</Typography>
         </CardContent>
-        {scheduleText && (
-          <CardActions className={classes.cardScheduleContainer}>
-            <Typography variant="subtitle2">{scheduleText}</Typography>
-          </CardActions>
-        )}
       </CardActionArea>
+      {scheduleText && (
+        <CardActions className={classes.cardScheduleContainer}>
+          <Typography id={resourceScheduleId} variant="subtitle2">
+            {scheduleText}
+          </Typography>
+        </CardActions>
+      )}
     </Card>
   );
 };

--- a/packages/upswyng-web/src/components/ResourceCard.tsx
+++ b/packages/upswyng-web/src/components/ResourceCard.tsx
@@ -16,9 +16,6 @@ interface StyleProps {
 }
 
 const useStyles = makeStyles((theme: Theme) => ({
-  card: {
-    width: "100%",
-  },
   cardImagePlaceHolderContainer: (styleProps: StyleProps) => ({
     background: styleProps.backgroundColor,
     position: "relative",
@@ -90,9 +87,9 @@ const ResourceCard = ({
   };
 
   return (
-    <Card className={classes.card} raised>
+    <Card raised>
       <CardActionArea
-        aria-describedby={scheduleText && resourceScheduleId}
+        aria-describedby={scheduleText ? resourceScheduleId : undefined}
         role="link"
         onClick={handleClick}
       >

--- a/packages/upswyng-web/src/components/ResourceCard.tsx
+++ b/packages/upswyng-web/src/components/ResourceCard.tsx
@@ -1,36 +1,23 @@
-import { colors, font } from "../App.styles";
-
+import Card from "@material-ui/core/Card";
+import CardActionArea from "@material-ui/core/CardActionArea";
+import CardActions from "@material-ui/core/CardActions";
+import CardContent from "@material-ui/core/CardContent";
+import CardMedia from "@material-ui/core/CardMedia";
 import Image from "material-ui-image";
-import { Link } from "react-router-dom";
 import React from "react";
 import { Theme } from "@material-ui/core/styles/createMuiTheme";
+import Typography from "@material-ui/core/Typography";
+import { colors } from "../App.styles";
 import makeStyles from "@material-ui/styles/makeStyles";
+import { useHistory } from "react-router-dom";
 
 interface StyleProps {
   backgroundColor: string;
 }
 
 const useStyles = makeStyles((theme: Theme) => ({
-  cardContainer: {
-    borderRadius: "6px",
-    color: theme.palette.common.white,
-    display: "flex",
-    flexDirection: "column",
-    flex: "1 1 auto",
-    overflow: "hidden",
-    "&:link,&:visited": {
-      textDecoration: "none",
-    },
-    "&:hover,&:active": {
-      textDecoration: "none",
-      "& > *:first-child": {
-        textDecoration: "underline",
-      },
-    },
-  },
-  cardImageContainer: {
-    position: "relative",
-    flex: "1 1 auto",
+  card: {
+    width: "100%",
   },
   cardImagePlaceHolderContainer: (styleProps: StyleProps) => ({
     background: styleProps.backgroundColor,
@@ -50,33 +37,8 @@ const useStyles = makeStyles((theme: Theme) => ({
       width: "80%",
     },
   }),
-  cardResourceName: {
-    bottom: 4,
-    color: theme.palette.common.white,
-    display: "flex",
-    flexDirection: "column",
-    fontSize: font.helpers.convertPixelsToRems(14),
-    fontWeight: 700,
-    padding: "0 8px 8px",
-    position: "absolute",
-    width: "100%",
-    textDecoration: "inherit",
-    textShadow: `0 3px 6px ${theme.palette.common.black}`,
-  },
-  cardFooter: {
-    alignItems: "stretch",
-    display: "flex",
-    flexDirection: "row",
-  },
   cardScheduleContainer: {
-    alignItems: "center",
     background: theme.palette.common.black,
-    display: "flex",
-    flex: "1 1 auto",
-    fontSize: font.helpers.convertPixelsToRems(12),
-    fontWeight: 600,
-    textDecoration: "none",
-    padding: "6px 8px",
   },
 }));
 
@@ -118,39 +80,48 @@ const ResourceCard = ({
   const classes = useStyles({
     backgroundColor: cardColor.placeholderBackgroundColor,
   });
+  const history = useHistory();
+  const resourceUrl = `/resource/${resourceId}`;
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    history.push(resourceUrl);
+  };
 
   return (
-    <Link
-      className={classes.cardContainer}
-      to={{
-        pathname: `/resource/${resourceId}`,
-      }}
-    >
-      <div className={classes.cardImageContainer}>
-        {resourceImage && (
-          <Image
-            aspectRatio={457 / 250}
-            color={cardColor.placeholderBackgroundColor}
-            src={resourceImage}
-            alt=""
-          />
+    <Card className={classes.card} raised>
+      <CardActionArea role="link" onClick={handleClick}>
+        <CardMedia
+          component={() =>
+            resourceImage ? (
+              <Image
+                alt=""
+                aspectRatio={457 / 250}
+                color={cardColor.placeholderBackgroundColor}
+                src={resourceImage}
+              />
+            ) : (
+              <div className={classes.cardImagePlaceHolderContainer}>
+                {placeholder &&
+                  React.cloneElement(placeholder, {
+                    color: cardColor.iconColor,
+                  })}
+              </div>
+            )
+          }
+        />
+        <CardContent>
+          <Typography gutterBottom variant="subtitle1">
+            {resourceName}
+          </Typography>
+        </CardContent>
+        {scheduleText && (
+          <CardActions className={classes.cardScheduleContainer}>
+            <Typography variant="subtitle2">{scheduleText}</Typography>
+          </CardActions>
         )}
-        {!resourceImage && (
-          <div className={classes.cardImagePlaceHolderContainer}>
-            {placeholder &&
-              React.cloneElement(placeholder, {
-                color: cardColor.iconColor,
-              })}
-          </div>
-        )}
-        <span className={classes.cardResourceName}>{resourceName}</span>
-      </div>
-      {scheduleText && (
-        <span className={classes.cardFooter}>
-          <span className={classes.cardScheduleContainer}>{scheduleText}</span>
-        </span>
-      )}
-    </Link>
+      </CardActionArea>
+    </Card>
   );
 };
 

--- a/packages/upswyng-web/src/components/ResourceCard.tsx
+++ b/packages/upswyng-web/src/components/ResourceCard.tsx
@@ -111,9 +111,7 @@ const ResourceCard = ({
           }
         />
         <CardContent>
-          <Typography gutterBottom variant="subtitle1">
-            {resourceName}
-          </Typography>
+          <Typography variant="subtitle1">{resourceName}</Typography>
         </CardContent>
         {scheduleText && (
           <CardActions className={classes.cardScheduleContainer}>

--- a/packages/upswyng-web/src/components/ResourceList.tsx
+++ b/packages/upswyng-web/src/components/ResourceList.tsx
@@ -1,8 +1,8 @@
+import Grid from "@material-ui/core/Grid";
 import LoadingSpinner from "./LoadingSpinner";
 import React from "react";
 import ResourceCard from "./ResourceCard";
 import { TResource } from "@upswyng/upswyng-types";
-import { font } from "../App.styles";
 import { getNextOpenText } from "../utils/schedule";
 import makeStyles from "@material-ui/styles/makeStyles";
 
@@ -13,25 +13,16 @@ interface Props {
 
 const useStyles = makeStyles({
   list: {
-    alignItems: "stretch",
-    display: "flex",
-    flexDirection: "row",
-    flexWrap: "wrap",
-    margin: `0 ${font.helpers.convertPixelsToRems(-8)}`,
     padding: 0,
-    width: "auto",
   },
   listItem: {
-    alignItems: "flex-start",
-    display: "flex",
-    flex: "0 1 50%",
     listStyleType: "none",
-    padding: font.helpers.convertPixelsToRems(8),
   },
 });
 
 const ResourceList = ({ placeholder, resources }: Props) => {
   const classes = useStyles();
+
   if (resources === undefined) {
     return <LoadingSpinner />;
   }
@@ -44,7 +35,13 @@ const ResourceList = ({ placeholder, resources }: Props) => {
         }
         const scheduleText = getNextOpenText(schedule);
         return (
-          <li className={classes.listItem} key={resourceId}>
+          <Grid
+            className={classes.listItem}
+            component="li"
+            item
+            key={resourceId}
+            xs={6}
+          >
             <ResourceCard
               index={index}
               placeholder={placeholder}
@@ -53,11 +50,21 @@ const ResourceList = ({ placeholder, resources }: Props) => {
               resourceName={name}
               scheduleText={scheduleText}
             />
-          </li>
+          </Grid>
         );
       }
     );
-    return <ul className={classes.list}>{listItems}</ul>;
+    return (
+      <Grid
+        alignItems="stretch"
+        className={classes.list}
+        component="ul"
+        container
+        spacing={3}
+      >
+        {listItems}
+      </Grid>
+    );
   }
 
   return (

--- a/packages/upswyng-web/src/components/WeeklySchedule.tsx
+++ b/packages/upswyng-web/src/components/WeeklySchedule.tsx
@@ -38,7 +38,7 @@ const WeeklySchedule = ({ items }: { items: TScheduleItem[] }) => {
           <Grid item xs={12} key={x.day}>
             <Grid container spacing={6}>
               <Grid item xs={6}>
-                <Typography component="h3" variant="subtitle2">
+                <Typography component="h3" variant="subtitle1">
                   {capitalize(x.day)}:
                 </Typography>
               </Grid>

--- a/packages/upswyng-web/src/theme/index.ts
+++ b/packages/upswyng-web/src/theme/index.ts
@@ -53,9 +53,16 @@ const typography = {
     fontSize: "1rem",
     fontWeight: 300,
   },
-  subtitle2: {
+  subtitle1: {
     fontSize: "1rem",
     fontWeight: 400,
+    lineHeight: 1.2,
+    margin: 0,
+  },
+  subtitle2: {
+    fontSize: "0.8rem",
+    fontWeight: 400,
+    lineHeight: 1.2,
     margin: 0,
   },
   caption: {

--- a/packages/upswyng-web/src/theme/index.ts
+++ b/packages/upswyng-web/src/theme/index.ts
@@ -8,7 +8,7 @@ const spacing = (factor: number): string => `${0.25 * factor}rem`;
 
 const palette = {
   common: { black: "#000", white: "#fff" },
-  background: { paper: "#3a3a3a", default: "#3a3a3a" },
+  background: { paper: "#252525", default: "#3a3a3a" },
   primary: {
     main: "#F05A28",
     contrastText: "#000",


### PR DESCRIPTION
This PR does not close an issue.

## What does this PR do?

- updates the resource list for categories and sub-categories to use [MUI's card component](https://material-ui.com/components/cards/#card)
- darkens the paper background, used on MUI cards, in the MUI theme
- overrides the paper background color in the main menu drawer to use the default app background

We noticed that the text laying on top of the image was occasionally difficult to read, so we're moving it off the image and implementing an updated layout

## Screenshot

<img width="471" alt="example of updated layout" src="https://user-images.githubusercontent.com/6598084/78156754-716ad100-73fc-11ea-926e-922f872f0918.png">


## How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![first try](https://media.giphy.com/media/JJhiRdcYfcokU/giphy.gif)
