### PR TITLE
add more prominent open/closed labels

### DIFF
--- a/packages/upswyng-web/src/components/ResourceCard.tsx
+++ b/packages/upswyng-web/src/components/ResourceCard.tsx
@@ -1,21 +1,24 @@
+import { getIsOpen, getNextOpenText } from "../utils/schedule";
 import Card from "@material-ui/core/Card";
 import CardActionArea from "@material-ui/core/CardActionArea";
 import CardActions from "@material-ui/core/CardActions";
 import CardContent from "@material-ui/core/CardContent";
 import CardMedia from "@material-ui/core/CardMedia";
+import Grid from "@material-ui/core/Grid";
 import Image from "material-ui-image";
 import React from "react";
 import { ResourceSchedule } from "@upswyng/upswyng-core";
+import ScheduleIcon from "@material-ui/icons/Schedule";
 import { TResource } from "@upswyng/upswyng-types";
 import { Theme } from "@material-ui/core/styles/createMuiTheme";
 import Typography from "@material-ui/core/Typography";
 import { colors } from "../App.styles";
-import { getNextOpenText } from "../utils/schedule";
 import makeStyles from "@material-ui/styles/makeStyles";
 import { useHistory } from "react-router-dom";
 
 interface StyleProps {
   backgroundColor: string;
+  isOpen: boolean | null;
 }
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -40,6 +43,10 @@ const useStyles = makeStyles((theme: Theme) => ({
   cardScheduleContainer: {
     background: theme.palette.common.black,
   },
+  cardScheduleText: (styleProps: StyleProps) => ({
+    color: styleProps.isOpen ? "green" : theme.palette.error.main,
+    fontWeight: 700,
+  }),
 }));
 
 interface TCardColor {
@@ -65,18 +72,21 @@ interface Props {
 }
 
 const ResourceCard = ({ index = 1, placeholder, resource }: Props) => {
+  const { name, resourceId, schedule, streetViewImage } = resource;
+
+  const parsedSchedule = ResourceSchedule.parse(schedule);
+  const isOpen = getIsOpen(parsedSchedule);
+  const scheduleText = getNextOpenText(parsedSchedule);
   const cardColor =
     typeof index === "number" && !(index % 2) ? cardColors[0] : cardColors[1];
   const classes = useStyles({
     backgroundColor: cardColor.placeholderBackgroundColor,
+    isOpen,
   });
   const history = useHistory();
 
-  const { name, resourceId, schedule, streetViewImage } = resource;
   const resourceUrl = `/resource/${resourceId}`;
   const resourceScheduleId = `${resourceId}-schedule`;
-  const parsedSchedule = ResourceSchedule.parse(schedule);
-  const scheduleText = getNextOpenText(parsedSchedule);
 
   const handleClick = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -113,11 +123,34 @@ const ResourceCard = ({ index = 1, placeholder, resource }: Props) => {
           <Typography variant="subtitle1">{name}</Typography>
         </CardContent>
       </CardActionArea>
-      {scheduleText && (
+      {typeof isOpen === "boolean" && scheduleText && (
         <CardActions className={classes.cardScheduleContainer}>
-          <Typography id={resourceScheduleId} variant="subtitle2">
-            {scheduleText}
-          </Typography>
+          <Grid container direction="column" spacing={1}>
+            <Grid
+              alignItems="center"
+              className={classes.cardScheduleText}
+              container
+              component={Typography}
+              id={resourceScheduleId}
+              item
+              spacing={2}
+              wrap="nowrap"
+              variant="subtitle1"
+            >
+              <Grid component={ScheduleIcon} item>
+                <ScheduleIcon fontSize="inherit" />
+              </Grid>
+              <Grid item>{isOpen ? "Open" : "Closed"}</Grid>
+            </Grid>
+            <Grid
+              component={Typography}
+              id={resourceScheduleId}
+              item
+              variant="subtitle2"
+            >
+              {scheduleText}
+            </Grid>
+          </Grid>
         </CardActions>
       )}
     </Card>

--- a/packages/upswyng-web/src/components/ResourceCard.tsx
+++ b/packages/upswyng-web/src/components/ResourceCard.tsx
@@ -12,18 +12,20 @@ import ScheduleIcon from "@material-ui/icons/Schedule";
 import { TResource } from "@upswyng/upswyng-types";
 import { Theme } from "@material-ui/core/styles/createMuiTheme";
 import Typography from "@material-ui/core/Typography";
-import { colors } from "../App.styles";
 import makeStyles from "@material-ui/styles/makeStyles";
 import { useHistory } from "react-router-dom";
 
 interface StyleProps {
-  backgroundColor: string;
+  index: number;
   isOpen: boolean | null;
 }
 
 const useStyles = makeStyles((theme: Theme) => ({
   cardImagePlaceHolderContainer: (styleProps: StyleProps) => ({
-    background: styleProps.backgroundColor,
+    background:
+      styleProps.index % 2 ? theme.palette.grey.A200 : theme.palette.grey[600],
+    color:
+      styleProps.index % 2 ? theme.palette.grey[600] : theme.palette.grey.A200,
     position: "relative",
     "&::before": {
       content: '""',
@@ -50,22 +52,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   }),
 }));
 
-interface TCardColor {
-  iconColor: string;
-  placeholderBackgroundColor: string;
-}
-
-const cardColors: TCardColor[] = [
-  {
-    iconColor: colors.greyMedium,
-    placeholderBackgroundColor: colors.greyLight,
-  },
-  {
-    iconColor: colors.greyLight,
-    placeholderBackgroundColor: colors.greyMedium,
-  },
-];
-
 interface Props {
   index?: number;
   placeholder?: React.ReactElement;
@@ -78,10 +64,8 @@ const ResourceCard = ({ index = 1, placeholder, resource }: Props) => {
   const parsedSchedule = ResourceSchedule.parse(schedule);
   const isOpen = getIsOpen(parsedSchedule);
   const scheduleText = getNextOpenText(parsedSchedule);
-  const cardColor =
-    typeof index === "number" && !(index % 2) ? cardColors[0] : cardColors[1];
   const classes = useStyles({
-    backgroundColor: cardColor.placeholderBackgroundColor,
+    index,
     isOpen,
   });
   const history = useHistory();
@@ -107,14 +91,14 @@ const ResourceCard = ({ index = 1, placeholder, resource }: Props) => {
               <Image
                 alt=""
                 aspectRatio={457 / 250}
-                color={cardColor.placeholderBackgroundColor}
+                color="transparent"
                 src={streetViewImage}
               />
             ) : (
               <div className={classes.cardImagePlaceHolderContainer}>
                 {placeholder &&
                   React.cloneElement(placeholder, {
-                    color: cardColor.iconColor,
+                    color: "inherit",
                   })}
               </div>
             )
@@ -138,8 +122,8 @@ const ResourceCard = ({ index = 1, placeholder, resource }: Props) => {
               wrap="nowrap"
               variant="subtitle1"
             >
-              <Grid component={ScheduleIcon} item>
-                <ScheduleIcon fontSize="inherit" />
+              <Grid alignContent="center" container item>
+                <ScheduleIcon color="inherit" fontSize="inherit" />
               </Grid>
               <Grid item>{isOpen ? "Open" : "Closed"}</Grid>
             </Grid>

--- a/packages/upswyng-web/src/components/ResourceCard.tsx
+++ b/packages/upswyng-web/src/components/ResourceCard.tsx
@@ -44,8 +44,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     background: theme.palette.common.black,
   },
   cardScheduleText: (styleProps: StyleProps) => ({
-    color: styleProps.isOpen ? "green" : theme.palette.error.main,
-    fontWeight: 700,
+    color: styleProps.isOpen
+      ? theme.palette.success.main
+      : theme.palette.error.main,
   }),
 }));
 

--- a/packages/upswyng-web/src/components/ResourceCard.tsx
+++ b/packages/upswyng-web/src/components/ResourceCard.tsx
@@ -5,9 +5,12 @@ import CardContent from "@material-ui/core/CardContent";
 import CardMedia from "@material-ui/core/CardMedia";
 import Image from "material-ui-image";
 import React from "react";
+import { ResourceSchedule } from "@upswyng/upswyng-core";
+import { TResource } from "@upswyng/upswyng-types";
 import { Theme } from "@material-ui/core/styles/createMuiTheme";
 import Typography from "@material-ui/core/Typography";
 import { colors } from "../App.styles";
+import { getNextOpenText } from "../utils/schedule";
 import makeStyles from "@material-ui/styles/makeStyles";
 import { useHistory } from "react-router-dom";
 
@@ -58,28 +61,22 @@ const cardColors: TCardColor[] = [
 interface Props {
   index?: number;
   placeholder?: React.ReactElement;
-  resourceId: string;
-  resourceImage: string | null;
-  resourceName: string;
-  scheduleText?: string;
+  resource: TResource;
 }
 
-const ResourceCard = ({
-  index = 1,
-  placeholder,
-  resourceId,
-  resourceName,
-  scheduleText,
-  resourceImage,
-}: Props) => {
+const ResourceCard = ({ index = 1, placeholder, resource }: Props) => {
   const cardColor =
     typeof index === "number" && !(index % 2) ? cardColors[0] : cardColors[1];
   const classes = useStyles({
     backgroundColor: cardColor.placeholderBackgroundColor,
   });
   const history = useHistory();
+
+  const { name, resourceId, schedule, streetViewImage } = resource;
   const resourceUrl = `/resource/${resourceId}`;
   const resourceScheduleId = `${resourceId}-schedule`;
+  const parsedSchedule = ResourceSchedule.parse(schedule);
+  const scheduleText = getNextOpenText(parsedSchedule);
 
   const handleClick = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -95,12 +92,12 @@ const ResourceCard = ({
       >
         <CardMedia
           component={() =>
-            resourceImage ? (
+            streetViewImage ? (
               <Image
                 alt=""
                 aspectRatio={457 / 250}
                 color={cardColor.placeholderBackgroundColor}
-                src={resourceImage}
+                src={streetViewImage}
               />
             ) : (
               <div className={classes.cardImagePlaceHolderContainer}>
@@ -113,7 +110,7 @@ const ResourceCard = ({
           }
         />
         <CardContent>
-          <Typography variant="subtitle1">{resourceName}</Typography>
+          <Typography variant="subtitle1">{name}</Typography>
         </CardContent>
       </CardActionArea>
       {scheduleText && (

--- a/packages/upswyng-web/src/components/ResourceCard.tsx
+++ b/packages/upswyng-web/src/components/ResourceCard.tsx
@@ -122,8 +122,10 @@ const ResourceCard = ({ index = 1, placeholder, resource }: Props) => {
               wrap="nowrap"
               variant="subtitle1"
             >
-              <Grid alignContent="center" container item>
-                <ScheduleIcon color="inherit" fontSize="inherit" />
+              <Grid item>
+                <Grid alignContent="center" container>
+                  <ScheduleIcon color="inherit" fontSize="inherit" />
+                </Grid>
               </Grid>
               <Grid item>{isOpen ? "Open" : "Closed"}</Grid>
             </Grid>

--- a/packages/upswyng-web/src/components/ResourceList.tsx
+++ b/packages/upswyng-web/src/components/ResourceList.tsx
@@ -2,6 +2,7 @@ import Grid from "@material-ui/core/Grid";
 import LoadingSpinner from "./LoadingSpinner";
 import React from "react";
 import ResourceCard from "./ResourceCard";
+import { ResourceSchedule } from "@upswyng/upswyng-core";
 import { TResource } from "@upswyng/upswyng-types";
 import { getNextOpenText } from "../utils/schedule";
 import makeStyles from "@material-ui/styles/makeStyles";
@@ -33,7 +34,8 @@ const ResourceList = ({ placeholder, resources }: Props) => {
         if (!name || !resourceId) {
           return null;
         }
-        const scheduleText = getNextOpenText(schedule);
+        const parsedSchedule = ResourceSchedule.parse(schedule);
+        const scheduleText = getNextOpenText(parsedSchedule);
         return (
           <Grid
             className={classes.listItem}

--- a/packages/upswyng-web/src/components/ResourceList.tsx
+++ b/packages/upswyng-web/src/components/ResourceList.tsx
@@ -2,9 +2,7 @@ import Grid from "@material-ui/core/Grid";
 import LoadingSpinner from "./LoadingSpinner";
 import React from "react";
 import ResourceCard from "./ResourceCard";
-import { ResourceSchedule } from "@upswyng/upswyng-core";
 import { TResource } from "@upswyng/upswyng-types";
-import { getNextOpenText } from "../utils/schedule";
 import makeStyles from "@material-ui/styles/makeStyles";
 
 interface Props {
@@ -29,33 +27,26 @@ const ResourceList = ({ placeholder, resources }: Props) => {
   }
 
   if (resources && resources.length) {
-    const listItems = resources.map(
-      ({ name, resourceId, schedule, streetViewImage }, index) => {
-        if (!name || !resourceId) {
-          return null;
-        }
-        const parsedSchedule = ResourceSchedule.parse(schedule);
-        const scheduleText = getNextOpenText(parsedSchedule);
-        return (
-          <Grid
-            className={classes.listItem}
-            component="li"
-            item
-            key={resourceId}
-            xs={6}
-          >
-            <ResourceCard
-              index={index}
-              placeholder={placeholder}
-              resourceId={resourceId}
-              resourceImage={streetViewImage}
-              resourceName={name}
-              scheduleText={scheduleText}
-            />
-          </Grid>
-        );
+    const listItems = resources.map((resource, index) => {
+      if (!resource.name || !resource.resourceId) {
+        return null;
       }
-    );
+      return (
+        <Grid
+          className={classes.listItem}
+          component="li"
+          item
+          key={resource.resourceId}
+          xs={6}
+        >
+          <ResourceCard
+            index={index}
+            placeholder={placeholder}
+            resource={resource}
+          />
+        </Grid>
+      );
+    });
     return (
       <Grid
         alignItems="stretch"

--- a/packages/upswyng-web/src/theme/index.ts
+++ b/packages/upswyng-web/src/theme/index.ts
@@ -17,6 +17,10 @@ const palette = {
     main: "#F4BD21",
     contrastText: "#000",
   },
+  success: {
+    main: "#77FF77",
+    contrastText: "#000",
+  },
   error: {
     main: "#BC2222",
     contrastText: "#fff",

--- a/packages/upswyng-web/src/utils/schedule.ts
+++ b/packages/upswyng-web/src/utils/schedule.ts
@@ -1,6 +1,5 @@
 import {
   TDay,
-  TResourceScheduleData,
   TSchedule,
   TScheduleItemOpenClose,
   TSchedulePeriod,
@@ -88,10 +87,7 @@ const getOpensAtText = ({ open }: TScheduleItemOpenClose) =>
     sameElse: "MMM Do",
   });
 
-export const getNextOpenText = (
-  scheduleData: TResourceScheduleData
-): string => {
-  const schedule = ResourceSchedule.parse(scheduleData);
+export const getNextOpenText = (schedule: ResourceSchedule): string => {
   if (schedule.alwaysOpen) {
     return "Open 24/7";
   }

--- a/packages/upswyng-web/src/utils/schedule.ts
+++ b/packages/upswyng-web/src/utils/schedule.ts
@@ -87,6 +87,24 @@ const getOpensAtText = ({ open }: TScheduleItemOpenClose) =>
     sameElse: "MMM Do",
   });
 
+export const getIsOpen = (schedule: ResourceSchedule): boolean | null => {
+  if (schedule.alwaysOpen) {
+    return true;
+  }
+
+  const currentDt = new Date();
+  const nextScheduleItemPeriod = schedule.getNextScheduleItemPeriod(currentDt);
+  if (!nextScheduleItemPeriod) {
+    return null;
+  }
+
+  if (currentDt.getTime() > nextScheduleItemPeriod.open.getTime()) {
+    return true;
+  }
+
+  return false;
+};
+
 export const getNextOpenText = (schedule: ResourceSchedule): string => {
   if (schedule.alwaysOpen) {
     return "Open 24/7";
@@ -102,5 +120,5 @@ export const getNextOpenText = (schedule: ResourceSchedule): string => {
     return `Closes at ${moment(nextScheduleItemPeriod.close).format("h:mm A")}`;
   }
 
-  return `Closed: open ${getOpensAtText(nextScheduleItemPeriod)}`;
+  return `open ${getOpensAtText(nextScheduleItemPeriod)}`;
 };


### PR DESCRIPTION
This PR does not close an issue.

## What does this PR do?

- adds more prominent open/closed labels to resource list
- moves individual resource parsing from resource list to card
- adds success color to theme palette
- removes unnecessary `CardColor` interface in `<ResourceCard/>`

## Screenshot

<img width="475" alt="example of closed and open labels" src="https://user-images.githubusercontent.com/6598084/78510440-55e02d00-7752-11ea-9c6a-627431b4d112.png">

## How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

<img alt="open, closed forever" src="https://i.giphy.com/media/l3q2Kgm3KOBUE6wF2/giphy.webp"/>
