### PR TITLE
🐛 Fix routing conficts between portal and web

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -52,14 +52,11 @@ export default function(options: TAppOptions) {
     .use(
       compression({ threshold: 0 }),
       cors(), // TODO: Lock this down to non-admin routes
-      sirv("static", {
-        dev,
-      }),
       bodyParser.json({}),
       bodyParser.urlencoded({
         extended: true,
         // retain raw body for use with Slack verification
-        verify: (req, res, buf, encoding) => {
+        verify: (req, _res, buf, encoding) => {
           if (buf && buf.length) {
             (req as any).rawBody = buf.toString(encoding || "utf8");
           }
@@ -82,6 +79,12 @@ export default function(options: TAppOptions) {
           }
         },
       ])
+    )
+    .use(
+      "/static",
+      sirv("static", {
+        dev,
+      })
     )
     .use(userMiddleware)
     .get("/callback", oidc(grantConfig), (_req, res) => {

--- a/packages/server/src/components/FacebookLoginButton.svelte
+++ b/packages/server/src/components/FacebookLoginButton.svelte
@@ -18,5 +18,5 @@
 </style>
 
 <a {href}>
-  <img alt="Continue with Facebook" src="/facebook_signin.png" />
+  <img alt="Continue with Facebook" src="/static/facebook_signin.png" />
 </a>

--- a/packages/server/src/components/GoogleLoginButton.svelte
+++ b/packages/server/src/components/GoogleLoginButton.svelte
@@ -18,5 +18,5 @@
 </style>
 
 <a {href}>
-  <img alt="Sign in with Google" src="/google_signin_dark_normal.png" />
+  <img alt="Sign in with Google" src="/static/google_signin_dark_normal.png" />
 </a>

--- a/packages/server/src/components/Nav.svelte
+++ b/packages/server/src/components/Nav.svelte
@@ -19,7 +19,9 @@
   <div class="container">
     <div class="navbar-brand">
       <a class="navbar-item" href="/provider">
-        <img alt="Upswyng: Resources within reach" src="upswyng_arrow.svg" />
+        <img
+          alt="Upswyng: Resources within reach"
+          src="static/upswyng_arrow.svg" />
       </a>
       <!-- svelte-ignore a11y-missing-attribute -->
       <a

--- a/packages/server/src/components/SlackLoginButton.svelte
+++ b/packages/server/src/components/SlackLoginButton.svelte
@@ -18,5 +18,5 @@
 </style>
 
 <a {href}>
-  <img alt="Sign in with Slack" src="/slack_signin.png" />
+  <img alt="Sign in with Slack" src="/static/slack_signin.png" />
 </a>

--- a/packages/server/src/routes/provider/alert/create.svelte
+++ b/packages/server/src/routes/provider/alert/create.svelte
@@ -657,7 +657,7 @@
                   <div class="level-right">
                     <img
                       alt="Upswyng icon mock"
-                      src="upswyng_arrow.svg"
+                      src="/static/upswyng_arrow.svg"
                       class="upswyng-icon" />
                   </div>
                 </div>

--- a/packages/server/src/routes/provider/bot.svelte
+++ b/packages/server/src/routes/provider/bot.svelte
@@ -158,7 +158,7 @@
           <img
             class="upswyngbot-logo"
             alt="The upswyngbot"
-            src="/upswyngbot.svg" />
+            src="/static/upswyngbot.svg" />
         </div>
         <div class="column">
           <h1 class="title is-family-monospace">

--- a/packages/server/src/routes/provider/index.svelte
+++ b/packages/server/src/routes/provider/index.svelte
@@ -23,7 +23,9 @@
     <div class="container">
       <div class="columns is-variable is-6 is-vcentered">
         <div class="column">
-          <img alt="upswyng: Resources within reach" src="upswyng_light.svg" />
+          <img
+            alt="UpSwyng: Resources within reach"
+            src="/static/upswyng_light.svg" />
         </div>
         <div class="column">
           <h1 class="title">Upswyng Service Provider Portal</h1>

--- a/packages/server/src/server.js
+++ b/packages/server/src/server.js
@@ -107,22 +107,45 @@ mongoose
         throw new Error(`Failed to create an app instance`);
       }
 
-      appInstance.use(
-        sirv("../web/build", {
-          dev,
-          maxAge: 2628000, // ~ 1 month
-        })
-      );
-
+      // Sapper App
       appInstance.use(
         sapper.middleware({
-          ignore: x => {
-            // ignore the route if it's not /api, /provider, /connect, /client
+          ignore: path => {
+            // see https://stackoverflow.com/questions/5296268/fastest-way-to-check-a-string-contain-another-substring-in-javascript
+            // ignore the route if it doesn't belong to the sapper app so that it falls
+            // through to the web client
+            return (
+              path.indexOf("api") !== 1 &&
+              path.indexOf("callback") !== 1 &&
+              path.indexOf("client") !== 1 && // this is the provider portal client, not the web client
+              path.indexOf("connect") !== 1 &&
+              path.indexOf("provider") !== 1
+            );
           },
           session: (req, _res) => {
             return { user: getUserFromRawUsers(req) };
           },
         })
+      );
+
+      // Web client
+      appInstance.use(
+        sirv(path.resolve(__dirname + "/../../../../web/build"), {
+          dev,
+          maxAge: 2628000, // ~ 1 month
+        })
+      );
+
+      // Catch react-router routes and serve the web client index.
+      // The regex ensures that 404s of provider routes will be shown
+      // the sapper app 404 page.
+      appInstance.use(
+        /^(?!\/api)(?!\/provider)(?!\/connect)(?!\/callback).*$/,
+        (_req, res) => {
+          res.sendFile(
+            path.resolve(__dirname + "/../../../../web/build/index.html")
+          );
+        }
       );
 
       const s = http.createServer(appInstance);

--- a/packages/server/src/template.html
+++ b/packages/server/src/template.html
@@ -7,8 +7,8 @@
 
     %sapper.base%
 
-    <link rel="manifest" href="manifest.json" />
-    <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    <link rel="manifest" href="static/manifest.json" />
+    <link rel="icon" type="image/x-icon" href="static/favicon.ico" />
 
     <!-- Sapper generates a <style> tag containing critical CSS
 	     for the current page. CSS for the rest of the app is

--- a/packages/server/src/utility/slackbot.ts
+++ b/packages/server/src/utility/slackbot.ts
@@ -170,7 +170,7 @@ export async function postEventLogMessage(e: TEventLog) {
       channel: CHANNEL,
       // TODO (rhinodavid): Remove hardcoded URL
       // Issue now is that if you use the SERVER_HOST slack can't access `localhost`
-      icon_url: `https://codeforboulder-upswyng-server.herokuapp.com/upswyngbot.svg`,
+      icon_url: `${HOST}/static/upswyngbot.svg`,
       text,
       /* eslint-enable @typescript-eslint/camelcase */
     });
@@ -189,7 +189,7 @@ export async function postTestMessage() {
       channel: CHANNEL,
       // TODO (rhinodavid): Remove hardcoded URL
       // Issue now is that if you use the SERVER_HOST slack can't access `localhost`
-      icon_url: `${HOST}/upswyngbot.svg`,
+      icon_url: `${HOST}/static/upswyngbot.svg`,
       text: `🔔 DING. It's ${new Date().toLocaleString()}`,
       /* eslint-enable @typescript-eslint/camelcase */
     });


### PR DESCRIPTION
- move all static resources for portal under `/static` directory
- make sapper app explicitly ignore paths that don't belong to the portal
- serve react root for non-sapper routes when no other middleware applies (fixes deep linking to web client)

This is the last big cleanup piece for the routing. The user should see a 404 page from the portal when appropriate; same for the web client. This, along with #375, also seems to solve the OAuth issues (knock on wood).