### PR TITLE
🤖 Create upswngbot command and worker job to delete all user sessions

### DIFF
--- a/packages/server/src/routes/api/bot/destroy-all-sessions.ts
+++ b/packages/server/src/routes/api/bot/destroy-all-sessions.ts
@@ -11,7 +11,7 @@ async function makeJobDestroyAllSessions(_req, res, _next, user: TUser) {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `:bomb: I'm *destorying all sessions* for you!`,
+        text: `:bomb: I'm *destroying all sessions* for you!`,
       },
     },
     {

--- a/packages/server/src/routes/api/bot/destroy-all-sessions.ts
+++ b/packages/server/src/routes/api/bot/destroy-all-sessions.ts
@@ -1,0 +1,54 @@
+import { TUser } from "@upswyng/types";
+import getName from "@afuggini/namegenerator";
+import handleCommandFromSlack from "../../../utility/handleCommandFromSlack";
+import mq from "../../../worker/mq";
+
+async function makeJobDestroyAllSessions(_req, res, _next, user: TUser) {
+  const jobName = getName("-");
+  mq.addJobDestroyAllSessions(jobName, user._id);
+  const blocks = [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `:bomb: I'm *destorying all sessions* for you!`,
+      },
+    },
+    {
+      type: "section",
+      text: {
+        text: `Your job name is _${jobName}_`,
+        type: "mrkdwn",
+      },
+    },
+  ];
+  const slackResponse = {
+    response_type: "in_channel", // eslint-disable-line @typescript-eslint/camelcase
+    blocks,
+  };
+
+  res.writeHead(200, { "Content-Type": "application/json" });
+  return res.end(JSON.stringify(slackResponse));
+}
+
+/**
+ * Adds a Destroy All Sessions job to the queue.
+ *
+ * Can be called from slack command `/destroy-all-sessions`.
+ */
+export async function post(req, res, next) {
+  const { response_url: responseUrl } = req.body;
+
+  if (responseUrl && responseUrl.includes("hooks.slack.com")) {
+    return handleCommandFromSlack(req, res, next, makeJobDestroyAllSessions);
+  }
+
+  // For now, only allow this endpoint to be called from Slack
+  res.writeHead(400, { "Content-Type": "application/json" });
+  return res.end(
+    JSON.stringify({
+      message:
+        "Tell upswyngbot /destroy-all-sessions to run the Destroy All Sessions job",
+    })
+  );
+}

--- a/packages/server/src/worker.ts
+++ b/packages/server/src/worker.ts
@@ -11,6 +11,8 @@ import {
   TJobCheckLinksResult,
   TJobCheckNewAlertsData,
   TJobCheckNewAlertsResult,
+  TJobDestroyAllSessionsData,
+  TJobDestroyAllSessionsResult,
   TJobSyncAlgoliaData,
   TJobSyncAlgoliaResult,
 } from "./worker/workerTypes";
@@ -25,6 +27,7 @@ import mongoose from "mongoose";
 import mq from "./worker/mq";
 import { processJobCheckLinks } from "./worker/processJobCheckLinks";
 import { processJobCheckNewAlerts } from "./worker/processJobCheckNewAlerts";
+import { processJobDestroyAllSessions } from "./worker/processJobDestroyAllSessions";
 import { processJobSyncAlgolia } from "./worker/processJobSyncAlgolia";
 import { processJobTest } from "./worker/processJobTest";
 import throng from "throng";
@@ -82,6 +85,14 @@ async function start() {
         case JobKind.CheckNewAlerts:
           return await processJobCheckNewAlerts(
             job as Job<TJobCheckNewAlertsData, TJobCheckNewAlertsResult>
+          );
+        case JobKind.DestroyAllSessions:
+          return await processJobDestroyAllSessions(
+            job as Job<
+              TJobDestroyAllSessionsData,
+              TJobDestroyAllSessionsResult
+            >,
+            mongoose.connection
           );
         case JobKind.Test:
           return await processJobTest(job as Job<TJobTestData, TJobTestResult>);

--- a/packages/server/src/worker/mq.ts
+++ b/packages/server/src/worker/mq.ts
@@ -12,6 +12,8 @@ import {
   TJobCheckNewAlertsData,
   TJobCheckNewAlertsResult,
   TJobData,
+  TJobDestroyAllSessionsData,
+  TJobDestroyAllSessionsResult,
   TJobSyncAlgoliaData,
   TJobSyncAlgoliaResult,
   TJobTestData,
@@ -118,6 +120,20 @@ async function addJobCheckNewAlerts(
   );
 }
 
+async function addJobDestroyAllSessions(
+  name: string = getName("-"),
+  userId
+): Promise<Job<TJobDestroyAllSessionsData, TJobDestroyAllSessionsResult>> {
+  return queue.add(
+    name,
+    { kind: JobKind.DestroyAllSessions, userId },
+    {
+      priority: 80,
+      jobId: new ObjectID().toHexString(),
+    }
+  );
+}
+
 async function addJobSyncAlgolia(
   name: string = getName("-"),
   userId
@@ -136,6 +152,7 @@ const mq = {
   addJobSyncAlgolia,
   addJobCheckLinks,
   addJobCheckNewAlerts,
+  addJobDestroyAllSessions,
   addJobTest,
   connection,
   getCounts,

--- a/packages/server/src/worker/processJobDestroyAllSessions.ts
+++ b/packages/server/src/worker/processJobDestroyAllSessions.ts
@@ -1,0 +1,26 @@
+import {
+  JobKind,
+  TJobDestroyAllSessionsData,
+  TJobDestroyAllSessionsResult,
+} from "./workerTypes";
+
+import { Job } from "bullmq";
+import mongoose from "mongoose";
+
+/**
+ * Wipes all the user sessions from the mongodb collection
+ */
+export async function processJobDestroyAllSessions(
+  job: Job<TJobDestroyAllSessionsData, TJobDestroyAllSessionsResult>,
+  connection: mongoose.Connection
+) {
+  const result = await connection.db.dropCollection("sessions");
+  if (result) {
+    job.updateProgress(100);
+    return {
+      kind: JobKind.DestroyAllSessions,
+    };
+  } else {
+    throw new Error(`Failed to remove sessions`);
+  }
+}

--- a/packages/server/src/worker/workerTypes.ts
+++ b/packages/server/src/worker/workerTypes.ts
@@ -8,8 +8,20 @@
 export enum JobKind {
   CheckLinks = "check_links", // visit the websites listed in Resources and check for broken URLs
   CheckNewAlerts = "check_new_alerts", // look for alerts whose start time has come and process them
+  DestroyAllSessions = "destroy_all_sessions", // wipes all the user sessions from the mongodb collection
   Test = "test", // no-op job used for testing the worker/queue
   SyncAlgolia = "sync_algolia", // update algolia index with latest resources
+}
+
+// DestroyAllSessions
+// wipes all the user sessions from the mongodb collection
+export interface TJobDestroyAllSessionsData {
+  kind: JobKind.DestroyAllSessions;
+  userId?: string; // _id of user who started this job
+}
+
+export interface TJobDestroyAllSessionsResult {
+  kind: JobKind.DestroyAllSessions;
 }
 
 // Test Job
@@ -76,10 +88,12 @@ export interface TJobSyncAlgoliaResult {
 export type TJobData =
   | TJobCheckLinksData
   | TJobCheckNewAlertsData
+  | TJobDestroyAllSessionsData
   | TJobTestData
   | TJobSyncAlgoliaData;
 export type TJobResult =
   | TJobCheckLinksResult
   | TJobCheckNewAlertsResult
+  | TJobDestroyAllSessionsResult
   | TJobTestResult
   | TJobSyncAlgoliaResult;


### PR DESCRIPTION
**Should land after #381**

When making OAuth configuration changes or if the session secret somehow got disclosed, it would be necessary to destroy all user sessions.

This PR adds a worker job to drop the session collection (Mongoose will recreate it) + an endpoint to handle the command from `upswyngbot`.

<img width="537" alt="Screen Shot 2020-05-20 at 10 33 57 PM" src="https://user-images.githubusercontent.com/5778036/82527275-43983380-9af3-11ea-9080-63d414020efb.png">

