### PR TITLE
fix: category colors and sorting

### DIFF
--- a/packages/common/src/colors.ts
+++ b/packages/common/src/colors.ts
@@ -1,0 +1,23 @@
+const colors: Record<string, string> = {
+  black: "#000",
+  blue: "#2C4198",
+  brown: "#AA6A03",
+  charcoal: "#3a3a3a",
+  gold: "#F4BD21",
+  green: "#68A840",
+  greyDark: "#3c3c3c",
+  greyMedium: "#707070",
+  greyLight: "#A2A2A2",
+  lavendar: "#9F6CBA",
+  orangeDark: "#CE5A30",
+  orangePrimary: "#F05A28",
+  orangeSecondary: "#DB5427",
+  pink: "#B146BF",
+  purple: "#5B4DC7",
+  red: "#BC2222",
+  rosewood: "#795161",
+  teal: "#40ACBF",
+  white: "#FFF",
+};
+
+export default colors;

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,5 +1,6 @@
 import { TScheduleItem as TScheduleItem_ } from "./ResourceSchedule";
 
+export { default as colors } from "./colors";
 export { default as ResourceSchedule } from "./ResourceSchedule";
 export { default as Time } from "./Time";
 export type TScheduleItem = TScheduleItem_;

--- a/packages/server/src/components/SubcategoryInput.svelte
+++ b/packages/server/src/components/SubcategoryInput.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { colors } from "@upswyng/common";
   import Select from "svelte-select";
 
   export let value = []; // TSubcategory[]
@@ -55,7 +56,7 @@
         <div>
           <div
             class="bullet"
-            style={`background-color: ${subcategory.parentCategory.color || 'gray'}`} />
+            style={`background-color: ${colors[subcategory.parentCategory.color] || 'gray'}`} />
           <div class="is-size-6 has-text-weight-semibold subcategory-name">
             {subcategory.parentCategory.name} | {subcategory.name}
           </div>
@@ -81,7 +82,7 @@
           <div>
             <div
               class="bullet"
-              style={`background-color: ${subcategory.parentCategory.color || 'gray'}`} />
+              style={`background-color: ${colors[subcategory.parentCategory.color] || 'gray'}`} />
             <div class="is-size-6 has-text-weight-semibold subcategory-name">
               {subcategory.parentCategory.name} | {subcategory.name}
             </div>

--- a/packages/server/src/routes/api/subcategories.ts
+++ b/packages/server/src/routes/api/subcategories.ts
@@ -3,8 +3,16 @@ import Subcategory from "../../models/Subcategory";
 export async function get(_req, res) {
   try {
     const subcategories = await Subcategory.getSubcategoryList();
+    const collator = new Intl.Collator("en");
+    const sortedSubcategories = subcategories.sort(
+      (subCatA, subCatB) =>
+        collator.compare(
+          subCatA.parentCategory.name,
+          subCatB.parentCategory.name
+        ) || collator.compare(subCatA.name, subCatB.name)
+    );
     res.writeHead(200, { "Content-Type": "application/json" });
-    return res.end(JSON.stringify({ subcategories }));
+    return res.end(JSON.stringify({ subcategories: sortedSubcategories }));
   } catch (e) {
     console.error(e);
     res.writeHead(500).end("Error fetching subcategories");

--- a/packages/web/src/App.styles.ts
+++ b/packages/web/src/App.styles.ts
@@ -1,28 +1,3 @@
-interface TColors {
-  [key: string]: string;
-}
-export const colors: TColors = {
-  black: "#000",
-  blue: "#2C4198",
-  brown: "#AA6A03",
-  charcoal: "#3a3a3a",
-  gold: "#F4BD21",
-  green: "#68A840",
-  greyDark: "#3c3c3c",
-  greyMedium: "#707070",
-  greyLight: "#A2A2A2",
-  lavendar: "#9F6CBA",
-  orangeDark: "#CE5A30",
-  orangePrimary: "#F05A28",
-  orangeSecondary: "#DB5427",
-  pink: "#B146BF",
-  purple: "#5B4DC7",
-  red: "#BC2222",
-  rosewood: "#795161",
-  teal: "#40ACBF",
-  white: "#FFF",
-};
-
 const baseFontSize = 16;
 const baseFontSizePercent = (16 / baseFontSize) * 100;
 export const font = {

--- a/packages/web/src/components/About.tsx
+++ b/packages/web/src/components/About.tsx
@@ -4,7 +4,7 @@ import Logo from "./Logo";
 import PageBanner from "./PageBanner";
 import React from "react";
 import Typography from "@material-ui/core/Typography";
-import { colors } from "../App.styles";
+import { colors } from "@upswyng/common";
 
 const About = () => (
   <Container>

--- a/packages/web/src/components/AlgoliaBadge.tsx
+++ b/packages/web/src/components/AlgoliaBadge.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { colors } from "../App.styles";
+import { colors } from "@upswyng/common";
 
 const AlgoliaBadge = () => (
   <svg

--- a/packages/web/src/components/BananaIcon.tsx
+++ b/packages/web/src/components/BananaIcon.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { colors } from "../App.styles";
+import { colors } from "@upswyng/common";
 
 interface Props {
   color?: string;

--- a/packages/web/src/components/Categories.tsx
+++ b/packages/web/src/components/Categories.tsx
@@ -14,7 +14,7 @@ import { TResourceCategory, TResourceSubcategory } from "../webTypes";
 import CategoryResults from "./CategoryResults";
 import Container from "@material-ui/core/Container";
 import React from "react";
-import { colors } from "../App.styles";
+import { colors } from "@upswyng/common";
 
 export interface TCategoryDefinition {
   color: keyof typeof colors;

--- a/packages/web/src/components/CoordinatedEntry.tsx
+++ b/packages/web/src/components/CoordinatedEntry.tsx
@@ -10,7 +10,7 @@ import PageBanner from "./PageBanner";
 import React from "react";
 import Typography from "@material-ui/core/Typography";
 import WarningIcon from "@material-ui/icons/Warning";
-import { colors } from "../App.styles";
+import { colors } from "@upswyng/common";
 import makeStyles from "@material-ui/core/styles/makeStyles";
 
 const useButtonStyles = makeStyles({

--- a/packages/web/src/components/DoorIcon.tsx
+++ b/packages/web/src/components/DoorIcon.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { colors } from "../App.styles";
+import { colors } from "@upswyng/common";
 
 interface Props {
   color?: string;

--- a/packages/web/src/components/HomeButton.tsx
+++ b/packages/web/src/components/HomeButton.tsx
@@ -1,7 +1,7 @@
-import { colors, font } from "../App.styles";
-
 import { ButtonProps } from "@material-ui/core/Button";
 import React from "react";
+import { colors } from "@upswyng/common";
+import { font } from "../App.styles";
 import makeStyles from "@material-ui/core/styles/makeStyles";
 
 interface HomeButtonProps extends ButtonProps {

--- a/packages/web/src/components/HomeButtons.tsx
+++ b/packages/web/src/components/HomeButtons.tsx
@@ -17,7 +17,7 @@ import HomeButton from "./HomeButton";
 import { HomeRouterLink } from "./HomeLink";
 import React from "react";
 import { THomeButtonRouterLink } from "../webTypes";
-import { colors } from "../App.styles";
+import { colors } from "@upswyng/common";
 
 export const routerLinkButtons: THomeButtonRouterLink[] = [
   {

--- a/packages/web/src/components/Hotlines.tsx
+++ b/packages/web/src/components/Hotlines.tsx
@@ -3,7 +3,7 @@ import HotlineCard from "./HotlineCard";
 import List from "@material-ui/core/List";
 import PageBanner from "./PageBanner";
 import React from "react";
-import { colors } from "../App.styles";
+import { colors } from "@upswyng/common";
 
 export const hotlineList = [
   {

--- a/packages/web/src/components/HygieneIcon.tsx
+++ b/packages/web/src/components/HygieneIcon.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { colors } from "../App.styles";
+import { colors } from "@upswyng/common";
 
 interface Props {
   color?: string;

--- a/packages/web/src/components/Logo.tsx
+++ b/packages/web/src/components/Logo.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { StyledComponentProps } from "@material-ui/core";
-import { colors } from "../App.styles";
+import { colors } from "@upswyng/common";
 
 const Logo = (props: StyledComponentProps) => (
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 318.4 108.22" {...props}>

--- a/packages/web/src/components/Map.tsx
+++ b/packages/web/src/components/Map.tsx
@@ -13,7 +13,7 @@ import IconButton from "@material-ui/core/IconButton";
 import LoadingSpinner from "./LoadingSpinner";
 import Snackbar from "@material-ui/core/Snackbar";
 import { TResource } from "@upswyng/types";
-import { colors } from "../App.styles";
+import { colors } from "@upswyng/common";
 import makeStyles from "@material-ui/core/styles/makeStyles";
 
 const boulderCoordinates = {

--- a/packages/web/src/components/NotFound.tsx
+++ b/packages/web/src/components/NotFound.tsx
@@ -6,7 +6,7 @@ import React from "react";
 import { Link as RouterLink } from "react-router-dom";
 import SearchForm from "./SearchForm";
 import Typography from "@material-ui/core/Typography";
-import { colors } from "../App.styles";
+import { colors } from "@upswyng/common";
 
 const NotFound = () => (
   <Container>

--- a/packages/web/src/components/PageBanner.tsx
+++ b/packages/web/src/components/PageBanner.tsx
@@ -4,7 +4,7 @@ import Box from "@material-ui/core/Box";
 import Grid from "@material-ui/core/Grid";
 import React from "react";
 import Typography from "@material-ui/core/Typography";
-import { colors } from "../App.styles";
+import { colors } from "@upswyng/common";
 
 interface Props {
   color?: string;

--- a/packages/web/src/components/PrivacyPolicy.tsx
+++ b/packages/web/src/components/PrivacyPolicy.tsx
@@ -4,7 +4,7 @@ import PageBanner from "./PageBanner";
 import React from "react";
 import { Link as RouterLink } from "react-router-dom";
 import Typography from "@material-ui/core/Typography";
-import { colors } from "../App.styles";
+import { colors } from "@upswyng/common";
 import makeStyles from "@material-ui/styles/makeStyles";
 
 const useStyles = makeStyles({

--- a/packages/web/src/components/Resource.tsx
+++ b/packages/web/src/components/Resource.tsx
@@ -24,7 +24,7 @@ import Services from "./Services";
 import { TResource } from "@upswyng/types";
 import { Theme } from "@material-ui/core/styles/createMuiTheme";
 import Typography from "@material-ui/core/Typography";
-import { colors } from "../App.styles";
+import { colors } from "@upswyng/common";
 import makeStyles from "@material-ui/core/styles/makeStyles";
 import { useHistory } from "react-router";
 import { useLastLocation } from "react-router-last-location";

--- a/packages/web/src/components/SocksIcon.tsx
+++ b/packages/web/src/components/SocksIcon.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { colors } from "../App.styles";
+import { colors } from "@upswyng/common";
 
 interface Props {
   color?: string;

--- a/packages/web/src/components/SubCategoryButton.tsx
+++ b/packages/web/src/components/SubCategoryButton.tsx
@@ -1,8 +1,9 @@
 import Button, { ButtonProps } from "@material-ui/core/Button";
-import { colors, font } from "../App.styles";
 import React from "react";
 import { Theme } from "@material-ui/core/styles/createMuiTheme";
+import { colors } from "@upswyng/common";
 import { darken } from "polished";
+import { font } from "../App.styles";
 import makeStyles from "@material-ui/styles/makeStyles";
 
 interface Props extends ButtonProps {

--- a/packages/web/src/components/TermsOfUse.tsx
+++ b/packages/web/src/components/TermsOfUse.tsx
@@ -2,7 +2,7 @@ import Container from "@material-ui/core/Container";
 import PageBanner from "./PageBanner";
 import React from "react";
 import Typography from "@material-ui/core/Typography";
-import { colors } from "../App.styles";
+import { colors } from "@upswyng/common";
 
 const TermsOfUse = () => (
   <Container>


### PR DESCRIPTION
This PR closes #394 and #382 

## What does this PR do?

- updates the `/api/subcategories` endpoint to sort subcategories first by category name and then by subcategory name
- adds central colors to the common package
- updates the subcategory editor in the provider portal to use common colors
- replaces local colors with common colors in the web package

<img width="412" alt="Screen Shot 2020-06-06 at 2 10 07 PM" src="https://user-images.githubusercontent.com/6598084/83953691-81899d00-a7ff-11ea-816b-6c135727adee.png">


## How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![colors!](https://media.giphy.com/media/3o85geDBXsTSmGDNPW/giphy.gif)
