### PR TITLE
add created by label to drafts

### DIFF
--- a/packages/server/src/components/ResourceScheduleDisplay.svelte
+++ b/packages/server/src/components/ResourceScheduleDisplay.svelte
@@ -27,7 +27,7 @@
     {/if}
   </div>
   <div>
-    <span class="has-text-weight-bold">Schedule Entrires</span>
+    <span class="has-text-weight-bold">Schedule Entries</span>
   </div>
   <ul>
     {#each schedule.getItems() as item}

--- a/packages/server/src/routes/provider/resource/draft/[_id].svelte
+++ b/packages/server/src/routes/provider/resource/draft/[_id].svelte
@@ -124,25 +124,53 @@
 
 <section class="section">
   <div class="container">
-    {#if existingResource}
-      <h1 class="title">
+    <h1 class="title">
+      {#if existingResource}
         Update Service Provider: {existingResource.name}
-        <span class="tag is-dark">Admin</span>
-      </h1>
+      {:else}Create New Service Provider{/if}
+      <span class="tag is-dark">Admin</span>
+    </h1>
+    {#if existingResource}
       <p class="subtitle">
         Service Provider ID:
         <a href={`/provider/resource/${existingResource.resourceId}`}>
           {existingResource.resourceId}
         </a>
       </p>
+    {/if}
+    {#if draftResource.createdBy}
+      <div class="columns">
+        <div class="column is-one-third-desktop is-half-tablet">
+          <div class="card">
+            <div class="card-header">
+              <h2 class="card-header-title">Draft Created By:</h2>
+            </div>
+            <div class="card-content">
+              <p class="content">
+                {#if draftResource.createdBy.name}
+                  <span class="icon">
+                    <i class="fas fa-user" aria-label="name" />
+                  </span>
+                  {draftResource.createdBy.name}
+                  <br />
+                {/if}
+                <span class="icon">
+                  <i class="fas fa-envelope" aria-label="email" />
+                </span>
+                <a href={`mailto:${draftResource.createdBy.email}`}>
+                  {draftResource.createdBy.email}
+                </a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    {/if}
+    {#if existingResource}
       <ResourceDiff
         leftResource={existingResource}
         rightResource={draftResource} />
     {:else}
-      <h1 class="title">
-        Create New Service Provider
-        <span class="tag is-dark">Admin</span>
-      </h1>
       <ResourceDisplay resource={draftResource} />
     {/if}
 


### PR DESCRIPTION
This PR closes #167.

## What does this PR do?

Adds a label to draft resources that informs who created the draft.

_example of draft created by user with both username and email_
<img width="673" alt="Screen Shot 2020-08-26 at 10 51 09 PM" src="https://user-images.githubusercontent.com/6598084/91385873-0c6ea800-e7ef-11ea-982f-8ff60b4320d2.png">

_example of draft created by user with only email (we're not guaranteed to have a name)_
<img width="735" alt="Screen Shot 2020-08-26 at 10 51 43 PM" src="https://user-images.githubusercontent.com/6598084/91385909-1c868780-e7ef-11ea-8eec-ae88ff46af10.png">

## How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/9S1yaD4TfqLueDAtRL/giphy.gif)
