### PR TITLE
fix: redirect route after draft deletion

### DIFF
--- a/packages/server/src/routes/provider/resource/draft/[_id].svelte
+++ b/packages/server/src/routes/provider/resource/draft/[_id].svelte
@@ -88,7 +88,7 @@
             ? `The draft of ${draftResource.name} was deleted`
             : "The draft resource was deleted"
         );
-        goto("/resource");
+        goto("/provider/resource");
       })
       .catch(e => (deleteError = e))
       .finally(() => (isDeleting = false));


### PR DESCRIPTION
This PR does not close an issue.

## What does this PR do?

Fixes the route of the redirect that occurs after deleting a draft.

## How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/2t9mb0HwTVn3mHj8AZ/giphy.gif)
