### PR TITLE
:sparkles: add ability to search for icons when creating an alert

### DIFF
--- a/packages/server/src/routes/provider/alert/create.svelte
+++ b/packages/server/src/routes/provider/alert/create.svelte
@@ -153,7 +153,7 @@
   }
 
   let isCustomIconSelectorOpen = false;
-  let iconSearch = "";
+  let iconSearchTerm = "";
   let iconSearchResults = [];
 
   function searchForCustomIcons() {
@@ -161,7 +161,7 @@
     const query = `{
       search(
         version: "5.12.1",
-        query: "${iconSearch}",
+        query: "${iconSearchTerm}",
         first: 16
       ) { id, Membership { free } }
     }`;
@@ -624,7 +624,7 @@
               class="input"
               type="text"
               placeholder="Search for an icon..."
-              bind:value={iconSearch} />
+              bind:value={iconSearchTerm} />
           </div>
           <div class="control">
             <button class="button" on:click={searchForCustomIcons}>

--- a/packages/server/src/routes/provider/alert/create.svelte
+++ b/packages/server/src/routes/provider/alert/create.svelte
@@ -594,27 +594,26 @@
       {#if isCustomIconSelectorOpen}
         <section class="modal-card-body">
           <div class="icon-choiced-container">
-            {#if iconSearchResults.length}
-              <div class="icon-choices">
-                {#each iconSearchResults as icon}
-                  <div class="icon-container">
-                    <button
-                      class="button is-large"
-                      class:has-background-info={tempIcon === icon}
-                      on:click={() => {
-                        tempIcon = icon;
-                        if (!Object.values(icons).includes(icon)) {
-                          icons[icon] = icon;
-                        }
-                      }}>
-                      <span class="icon is-large">
-                        <i class={`${icon} fa-2x`} />
-                      </span>
-                    </button>
-                  </div>
-                {/each}
-              </div>
-            {:else if !iconSearchResults.length && searchSubmitted}
+            <div class="icon-choices">
+              {#each iconSearchResults as icon}
+                <div class="icon-container">
+                  <button
+                    class="button is-large"
+                    class:has-background-info={tempIcon === icon}
+                    on:click={() => {
+                      tempIcon = icon;
+                      if (!Object.values(icons).includes(icon)) {
+                        icons[icon] = icon;
+                      }
+                    }}>
+                    <span class="icon is-large">
+                      <i class={`${icon} fa-2x`} />
+                    </span>
+                  </button>
+                </div>
+              {/each}
+            </div>
+            {#if !iconSearchResults.length && searchSubmitted}
               <div class="notification is-info">No results found.</div>
             {/if}
           </div>

--- a/packages/server/src/routes/provider/alert/create.svelte
+++ b/packages/server/src/routes/provider/alert/create.svelte
@@ -152,6 +152,36 @@
     }
   }
 
+  let isCustomIconSelectorOpen = false;
+  let iconSearch = "";
+  let iconSearchResults = [];
+
+  function searchForCustomIcons() {
+    iconSearchResults = [];
+    const query = `{
+      search(
+        version: "latest",
+        query: "${iconSearch}",
+        first: 16
+      ) { id, Membership { free } }
+    }`;
+
+    fetch("https://api.fontawesome.com", {
+      method: "POST",
+      body: JSON.stringify({ query }),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    })
+      .then(async resp => {
+        const { data } = await resp.json();
+        iconSearchResults = data.search
+          .filter(({ Membership }) => Membership.free.length > 0)
+          .map(icon => `fas fa-${icon.id}`);
+      })
+      .catch(e => (errorMessage = e));
+  }
+
   let isIconSelectorOpen = false;
   let isColorSelectorOpen = false;
   let isSubmitDialogOpen = false;
@@ -236,6 +266,10 @@
     display: flex;
     justify-content: center;
     align-items: center;
+  }
+
+  .icon-search-bar {
+    margin-top: 1em;
   }
 
   .color-picker-container,
@@ -547,36 +581,99 @@
         <button
           class="delete"
           aria-label="close"
-          on:click={() => (isIconSelectorOpen = false)} />
-      </header>
-      <section class="modal-card-body">
-        <div class="icon-choiced-container">
-          <div class="icon-choices">
-            {#each Object.values(icons) as icon}
-              <div class="icon-container">
-                <button
-                  class="button is-large"
-                  class:has-background-info={tempIcon === icon}
-                  on:click={() => (tempIcon = icon)}>
-                  <span class="icon is-large">
-                    <i class={`${icon} fa-2x`} />
-                  </span>
-                </button>
-              </div>
-            {/each}
-          </div>
-        </div>
-      </section>
-      <footer class="modal-card-foot">
-        <button
-          class="button is-success"
           on:click={() => {
-            alertIcon = tempIcon;
             isIconSelectorOpen = false;
-          }}>
-          Save changes
-        </button>
-      </footer>
+            isCustomIconSelectorOpen = false;
+          }} />
+      </header>
+      {#if isCustomIconSelectorOpen}
+        <section class="modal-card-body">
+          <div class="icon-choiced-container">
+            <div class="icon-choices">
+              {#each iconSearchResults as icon}
+                <div class="icon-container">
+                  <button
+                    class="button is-large"
+                    class:has-background-info={tempIcon === icon}
+                    on:click={() => {
+                      tempIcon = icon;
+                      icons[icon] = icon;
+                    }}>
+                    <span class="icon is-large">
+                      <i class={`${icon} fa-2x`} />
+                    </span>
+                  </button>
+                </div>
+              {/each}
+            </div>
+          </div>
+          <div class="control icon-search-bar">
+            <input
+              class="input"
+              type="text"
+              placeholder="Search for an icon..."
+              bind:value={iconSearch} />
+          </div>
+          <div class="control">
+            <button class="button" on:click={searchForCustomIcons}>
+              Search
+            </button>
+          </div>
+        </section>
+        <footer class="modal-card-foot">
+          <button
+            class="button is-success"
+            on:click={() => {
+              alertIcon = tempIcon;
+              isIconSelectorOpen = false;
+            }}>
+            Save changes
+          </button>
+          <button
+            class="button is-info"
+            on:click={() => {
+              isCustomIconSelectorOpen = false;
+            }}>
+            Back
+          </button>
+        </footer>
+      {:else}
+        <section class="modal-card-body">
+          <div class="icon-choiced-container">
+            <div class="icon-choices">
+              {#each Object.values(icons) as icon}
+                <div class="icon-container">
+                  <button
+                    class="button is-large"
+                    class:has-background-info={tempIcon === icon}
+                    on:click={() => (tempIcon = icon)}>
+                    <span class="icon is-large">
+                      <i class={`${icon} fa-2x`} />
+                    </span>
+                  </button>
+                </div>
+              {/each}
+            </div>
+          </div>
+        </section>
+        <footer class="modal-card-foot">
+          <button
+            class="button is-success"
+            on:click={() => {
+              alertIcon = tempIcon;
+              isIconSelectorOpen = false;
+            }}>
+            Save changes
+          </button>
+          <button
+            class="button is-info"
+            on:click={() => {
+              isCustomIconSelectorOpen = true;
+            }}>
+            Search For Icons
+          </button>
+        </footer>
+      {/if}
     </div>
   </div>
 

--- a/packages/server/src/routes/provider/alert/create.svelte
+++ b/packages/server/src/routes/provider/alert/create.svelte
@@ -39,6 +39,7 @@
     tent: "fas fa-campground",
     thermometer: "fas fa-thermometer-three-quarters",
     tooth: "fas fa-tooth",
+    wind: "fas fa-wind",
   };
 
   const alertTypes = {

--- a/packages/server/src/routes/provider/alert/create.svelte
+++ b/packages/server/src/routes/provider/alert/create.svelte
@@ -160,7 +160,7 @@
     iconSearchResults = [];
     const query = `{
       search(
-        version: "latest",
+        version: "5.12.1",
         query: "${iconSearch}",
         first: 16
       ) { id, Membership { free } }
@@ -176,10 +176,16 @@
       .then(async resp => {
         const { data } = await resp.json();
         iconSearchResults = data.search
-          .filter(({ Membership }) => Membership.free.length > 0)
+          .filter(({ Membership }) => Membership.free.includes("solid"))
           .map(icon => `fas fa-${icon.id}`);
+        if (iconSearchResults.length === 0) {
+          iconSearchResults = false;
+        }
       })
-      .catch(e => (errorMessage = e));
+      .catch(e => {
+        console.error(e);
+        iconSearchResults = false;
+      });
   }
 
   let isIconSelectorOpen = false;
@@ -269,7 +275,7 @@
   }
 
   .icon-search-bar {
-    margin-top: 1em;
+    margin: 1em 0;
   }
 
   .color-picker-container,
@@ -589,23 +595,29 @@
       {#if isCustomIconSelectorOpen}
         <section class="modal-card-body">
           <div class="icon-choiced-container">
-            <div class="icon-choices">
-              {#each iconSearchResults as icon}
-                <div class="icon-container">
-                  <button
-                    class="button is-large"
-                    class:has-background-info={tempIcon === icon}
-                    on:click={() => {
-                      tempIcon = icon;
-                      icons[icon] = icon;
-                    }}>
-                    <span class="icon is-large">
-                      <i class={`${icon} fa-2x`} />
-                    </span>
-                  </button>
-                </div>
-              {/each}
-            </div>
+            {#if iconSearchResults}
+              <div class="icon-choices">
+                {#each iconSearchResults as icon}
+                  <div class="icon-container">
+                    <button
+                      class="button is-large"
+                      class:has-background-info={tempIcon === icon}
+                      on:click={() => {
+                        tempIcon = icon;
+                        icons[icon] = icon;
+                      }}>
+                      <span class="icon is-large">
+                        <i class={`${icon} fa-2x`} />
+                      </span>
+                    </button>
+                  </div>
+                {/each}
+              </div>
+            {:else}
+              <div>
+                <h5>No results found</h5>
+              </div>
+            {/if}
           </div>
           <div class="control icon-search-bar">
             <input


### PR DESCRIPTION
This PR closes #414 

## What does this PR do?

1. Adds an interface to query the FontAwesome GraphQL API for useable icons and select one for an alert.
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/51095001/92339864-68e68880-f075-11ea-8a73-fa365a647502.gif)

<img width="1472" alt="Screen Shot 2020-09-06 at 7 23 06 PM" src="https://user-images.githubusercontent.com/51095001/92340119-67699000-f076-11ea-8bed-47df92ad40d0.png">

2. Adds the wind Icon as a default option

## How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/3oKHWwZRPApnDeDrva/giphy.gif)
