### PR TITLE
fix: update the category endpoint to only return non-trashed resources

### DIFF
--- a/packages/server/src/models/Category.ts
+++ b/packages/server/src/models/Category.ts
@@ -95,12 +95,19 @@ CategorySchema.statics.getCategoryList = async function(): Promise<
 };
 
 CategorySchema.statics.getByStub = async function(
-  stub: string
+  stub: string,
+  includeDeletedResources: boolean = false
 ): Promise<TCategoryDocument | null> {
-  return await this.findOne({ stub }).populate({
+  const result = await this.findOne({ stub }).populate({
     path: "subcategories",
     populate: { path: "resources" },
   });
+  if (result && !includeDeletedResources) {
+    result.subcategories.forEach(subcategory => {
+      subcategory.resources = subcategory.resources.filter(r => !r.deleted);
+    });
+  }
+  return result;
 };
 
 /**


### PR DESCRIPTION
This PR does not close an issue.

## What does this PR do?

Updates the category endpoint to not return trashed resources.

## How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![you get out of here](https://media.giphy.com/media/Tnchbhzt4fQQM/giphy.gif)
