### PR TITLE
fix: job training routing

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -47,7 +47,7 @@ class App extends Component {
                 <Route exact path="/about" component={About} />
                 <Route path="/coordinated-entry" component={CoordinatedEntry} />
                 <Route path="/shelters" component={Shelters} />
-                <Route path="/job-training" component={JobTraining} />
+                <Route path="/job_training" component={JobTraining} />
                 <Route path="/health" component={Health} />
                 <Route path="/hygiene" component={Hygiene} />
                 <Route exact path="/hotlines" component={Hotlines} />

--- a/packages/web/src/components/HomeButtons.tsx
+++ b/packages/web/src/components/HomeButtons.tsx
@@ -99,7 +99,7 @@ export const routerLinkButtons: THomeButtonRouterLink[] = [
     translationKey: "home:jobTraining",
     icon: BusinessCenterIcon,
     linkProps: {
-      to: "/job-training",
+      to: "/job_training",
     },
     color: colors.lavendar,
   },


### PR DESCRIPTION
This PR does not close an issue.

## What does this PR do?

This fixes an issue with the "Job Training" category routing that was displaying our 404 page on sub-categories.

## How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![its not here](https://media.giphy.com/media/3ohfFfWcBfxW5Tm0Ra/giphy.gif)
