### PR TITLE
Non-admin draft resource view

### DIFF
--- a/packages/server/src/routes/provider/resource/draft/[_id].svelte
+++ b/packages/server/src/routes/provider/resource/draft/[_id].svelte
@@ -4,6 +4,8 @@
   export async function preload({ params, query }, { user }) {
     let draftResource = null;
     if (!user.isAdmin) {
+      // If user is not an admin, make sure the draft they're trying to view is
+      // one of their own
       const draftsForUserResponse = await this.fetch("/api/resources/drafts/mine", {
         credentials: "same-origin",
       });

--- a/packages/server/src/routes/provider/resource/draft/[_id].svelte
+++ b/packages/server/src/routes/provider/resource/draft/[_id].svelte
@@ -2,6 +2,11 @@
   import { ResourceSchedule } from "@upswyng/common";
 
   export async function preload({ params, query }, { user }) {
+    if(!user) {
+      this.error(401, "You don't have permission to view this page");
+      return;
+    } 
+
     let draftResource = null;
     if (!user.isAdmin) {
       // If user is not an admin, make sure the draft they're trying to view is
@@ -11,11 +16,13 @@
       });
       if (draftsForUserResponse.status !== 200) {
         this.error(draftsForUserResponse.status, draftsForUserResponse.message);
+        return;
       }
       const {draftResources} = await draftsForUserResponse.json();
       draftResource = draftResources.find(draft => draft._id === params._id);
       if(!draftResource) {
         this.error(401, "You don't have permission to view this page");
+        return;
       } 
     } else {
       const draftResourceResponse = await this.fetch(
@@ -23,6 +30,7 @@
       );
       if (draftResourceResponse.status !== 200) {
         this.error(draftResourceResponse.status, draftResourceResponse.message);
+        return;
       }
       draftResource = (await draftResourceResponse.json()).draftResource;
     }


### PR DESCRIPTION
This PR closes #422 

## What does this PR do?
Renders a simple view of the draft resource for non-admin users, while hiding the admin-specific approve/delete draft buttons.

Feature/improvement ideas:
1. I think this screen should have an info banner at the top along the lines of: "Your draft resource has been submitted and is currently awaiting review by one of our administrators". I think that would be good on the screen where you create the draft as well. The process (create draft -> await approval by admin -> resource created) wasn't clear to me from the provider portal until I started looking at the code.
2. Render a `ResourceEditor` (same component used to create the draft) on this screen, so that a user can make corrections to their draft. Bit complicated because we get into needing to lock the draft while it's under review etc., but I think it could be high value because otherwise (from how I understand the process), correcting even a small typo in the initial draft is a time consuming process for the user (await approval, then submit the fix and await approval again?).

## How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](https://media.giphy.com/media/xSM46ernAUN3y/giphy.gif)
