### PR TITLE
fix: move comment headers to top of comment groups

### DIFF
--- a/packages/web/src/components/Schedule.tsx
+++ b/packages/web/src/components/Schedule.tsx
@@ -7,6 +7,7 @@ import MonthlySchedule from "./MonthlySchedule";
 import { RRule } from "rrule";
 import React from "react";
 import { TResourceScheduleData } from "@upswyng/types";
+import Typography from "@material-ui/core/Typography";
 
 interface ScheduleProps {
   schedule: TResourceScheduleData;
@@ -41,7 +42,11 @@ const Schedule = ({ schedule }: ScheduleProps) => {
           ) as TScheduleItem[];
           return (
             <React.Fragment key={comment}>
-              {comment !== "_no_comment_" && <div>{comment}</div>}
+              {comment !== "_no_comment_" && (
+                <Grid item>
+                  <Typography variant="h3">{comment}</Typography>
+                </Grid>
+              )}
               {!!weeklyItems.length && (
                 <Grid item>
                   <WeeklySchedule items={weeklyItems} />

--- a/packages/web/src/components/Schedule.tsx
+++ b/packages/web/src/components/Schedule.tsx
@@ -41,6 +41,7 @@ const Schedule = ({ schedule }: ScheduleProps) => {
           ) as TScheduleItem[];
           return (
             <React.Fragment key={comment}>
+              {comment !== "_no_comment_" && <div>{comment}</div>}
               {!!weeklyItems.length && (
                 <Grid item>
                   <WeeklySchedule items={weeklyItems} />
@@ -56,7 +57,6 @@ const Schedule = ({ schedule }: ScheduleProps) => {
                   <MonthlySchedule items={monthlyItems} />
                 </Grid>
               )}
-              {comment !== "_no_comment_" && <div>{comment}</div>}
             </React.Fragment>
           );
         })}


### PR DESCRIPTION
This PR does not close an issue.

## What does this PR do?

Moves comment headers to the top of schedules rather than appearing below.

## How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![man upside down saying this is totally normal](https://media.giphy.com/media/42AGxbp0gpPvmCD6TJ/giphy.gif)
