### PR TITLE
feat: add hours warning to resource page

### DIFF
--- a/packages/common/src/i18n/en.ts
+++ b/packages/common/src/i18n/en.ts
@@ -147,6 +147,8 @@ export default {
     address: "Address",
     phoneNumber: "Phone Number",
     website: "Website",
+    covidHours: "Hours may be different due to COVID-19.",
+    checkWebsite: "Please check their website for up-to-date info.",
     hoursOfOperation: "Hours of Operation",
     reportAProblem: "Report a Problem",
     services: "Services",

--- a/packages/common/src/i18n/en.ts
+++ b/packages/common/src/i18n/en.ts
@@ -147,7 +147,7 @@ export default {
     address: "Address",
     phoneNumber: "Phone Number",
     website: "Website",
-    covidHours: "Hours may be different due to COVID-19.",
+    covidWarning: "COVID-19 may affect normal business hours and operations.",
     checkWebsite: "Please check their website for up-to-date info.",
     hoursOfOperation: "Hours of Operation",
     reportAProblem: "Report a Problem",

--- a/packages/common/src/i18n/es.ts
+++ b/packages/common/src/i18n/es.ts
@@ -149,7 +149,8 @@ export default {
     address: "Dirección",
     phoneNumber: "Número de Teléfono",
     website: "Sitio Web",
-    covidHours: "Los horarios pueden ser diferentes debido a COVID-19.",
+    covidWarning:
+      "COVID-19 puede afectar el horario comercial y las operaciones normales.",
     checkWebsite: "Consulte su sitio web para obtener información actualizada.",
     hoursOfOperation: "Horas de Operación",
     reportAProblem: "Reportar un Problema",

--- a/packages/common/src/i18n/es.ts
+++ b/packages/common/src/i18n/es.ts
@@ -149,6 +149,8 @@ export default {
     address: "Dirección",
     phoneNumber: "Número de Teléfono",
     website: "Sitio Web",
+    covidHours: "Los horarios pueden ser diferentes debido a COVID-19.",
+    checkWebsite: "Consulte su sitio web para obtener información actualizada.",
     hoursOfOperation: "Horas de Operación",
     reportAProblem: "Reportar un Problema",
     services: "Servicios",

--- a/packages/web/src/components/Resource.tsx
+++ b/packages/web/src/components/Resource.tsx
@@ -112,6 +112,14 @@ export const Resource = () => {
         />
       )}
       <List component="div">
+        <ListItem component={Card}>
+          <ListItemIcon classes={listIconClasses}>
+            <WarningIcon color="secondary" />
+          </ListItemIcon>
+          <ListItemText>{`${t("covidWarning")} ${
+            !!resource.website ? t("checkWebsite") : ""
+          }`}</ListItemText>
+        </ListItem>
         {resource.address && (
           <ListItem component="div">
             <ListItemIcon classes={listIconClasses}>
@@ -165,22 +173,14 @@ export const Resource = () => {
         )}
         {!!resource.schedule._items.length && (
           <>
-            <ListItem component={Card}>
-              <ListItemIcon classes={listIconClasses}>
-                <WarningIcon color="secondary" />
-              </ListItemIcon>
-              <Typography component="h2" variant="srOnly">
-                {t("hoursOfOperation")}
-              </Typography>
-              <ListItemText>{`${t("covidHours")} ${
-                !!resource.website ? t("checkWebsite") : ""
-              }`}</ListItemText>
-            </ListItem>
             <ListItem component="div">
               <ListItemIcon classes={listIconClasses}>
                 <ScheduleIcon titleAccess={t("hoursOfOperation")} />
               </ListItemIcon>
               <ListItemText>
+                <Typography component="h2" variant="srOnly">
+                  {t("hoursOfOperation")}
+                </Typography>
                 <Schedule schedule={resource.schedule} />
               </ListItemText>
             </ListItem>

--- a/packages/web/src/components/Resource.tsx
+++ b/packages/web/src/components/Resource.tsx
@@ -172,19 +172,17 @@ export const Resource = () => {
           </ListItem>
         )}
         {!!resource.schedule._items.length && (
-          <>
-            <ListItem component="div">
-              <ListItemIcon classes={listIconClasses}>
-                <ScheduleIcon titleAccess={t("hoursOfOperation")} />
-              </ListItemIcon>
-              <ListItemText>
-                <Typography component="h2" variant="srOnly">
-                  {t("hoursOfOperation")}
-                </Typography>
-                <Schedule schedule={resource.schedule} />
-              </ListItemText>
-            </ListItem>
-          </>
+          <ListItem component="div">
+            <ListItemIcon classes={listIconClasses}>
+              <ScheduleIcon titleAccess={t("hoursOfOperation")} />
+            </ListItemIcon>
+            <ListItemText>
+              <Typography component="h2" variant="srOnly">
+                {t("hoursOfOperation")}
+              </Typography>
+              <Schedule schedule={resource.schedule} />
+            </ListItemText>
+          </ListItem>
         )}
         <ListItem component="div">
           <Typography variant="srOnly">{t("services")}</Typography>

--- a/packages/web/src/components/Resource.tsx
+++ b/packages/web/src/components/Resource.tsx
@@ -2,6 +2,7 @@ import { TCategoryDefinition, categories } from "./Categories";
 
 import BannerColorContext from "./BannerColorContext";
 import Button from "@material-ui/core/Button/Button";
+import Card from "@material-ui/core/Card";
 import Container from "@material-ui/core/Container";
 import FavoriteResourceFAB from "./FavoriteResourceFAB";
 import Image from "material-ui-image";
@@ -25,6 +26,7 @@ import Services from "./Services";
 import { TResource } from "@upswyng/types";
 import { Theme } from "@material-ui/core/styles/createMuiTheme";
 import Typography from "@material-ui/core/Typography";
+import WarningIcon from "@material-ui/icons/Warning";
 import { colors } from "@upswyng/common";
 import makeStyles from "@material-ui/core/styles/makeStyles";
 import { useHistory } from "react-router";
@@ -162,17 +164,27 @@ export const Resource = () => {
           </ListItem>
         )}
         {!!resource.schedule._items.length && (
-          <ListItem component="div">
-            <ListItemIcon classes={listIconClasses}>
-              <ScheduleIcon titleAccess={t("hoursOfOperation")} />
-            </ListItemIcon>
-            <ListItemText>
+          <>
+            <ListItem component={Card}>
+              <ListItemIcon classes={listIconClasses}>
+                <WarningIcon color="secondary" />
+              </ListItemIcon>
               <Typography component="h2" variant="srOnly">
                 {t("hoursOfOperation")}
               </Typography>
-              <Schedule schedule={resource.schedule} />
-            </ListItemText>
-          </ListItem>
+              <ListItemText>{`${t("covidHours")} ${
+                !!resource.website ? t("checkWebsite") : ""
+              }`}</ListItemText>
+            </ListItem>
+            <ListItem component="div">
+              <ListItemIcon classes={listIconClasses}>
+                <ScheduleIcon titleAccess={t("hoursOfOperation")} />
+              </ListItemIcon>
+              <ListItemText>
+                <Schedule schedule={resource.schedule} />
+              </ListItemText>
+            </ListItem>
+          </>
         )}
         <ListItem component="div">
           <Typography variant="srOnly">{t("services")}</Typography>


### PR DESCRIPTION
This PR does not close an issue.

## What does this PR do?

Adds a warning above the hours on each resource, instructing users to check website for more details.

<img width="478" alt="screen short of warning, COVID-19 may affect normal business hours and operations. Please check their website for up-to-date info." src="https://user-images.githubusercontent.com/6598084/122655092-2aeeb880-d10d-11eb-8bc7-c5929f377148.png">

This is important because the situation surrounding COVID-19 is changing weekly. We aren't in a state where we can guarantee up-to-date information so it's best to warn them to contact the provider for more details.

## How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![you've been wanred](https://media.giphy.com/media/Q87XzlKSuHqnT2FEHE/giphy.gif)
