### PR TITLE
fix issue 487: HomeButton heights

### DIFF
--- a/packages/web/src/components/HomeButton.tsx
+++ b/packages/web/src/components/HomeButton.tsx
@@ -26,6 +26,7 @@ const useStyles = makeStyles({
     textDecoration: "none",
     textTransform: "none",
     width: "100%",
+    height: "100%",
     "&:hover": {
       background: props.buttonColor || colors.greyDark,
       filter: "brightness(95%)",


### PR DESCRIPTION
This PR closes #487

## What does this PR do?
Fixes the issue where the HomeButton background would not match the height of its row if its neighbor had a greater height. 

## How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![:partying_face:](https://media.giphy.com/media/o0vwzuFwCGAFO/giphy.gif?cid=ecf05e47nu2zjvp1xt2ftcrzayzevvgd0fbrk5o4gidh12xd&rid=giphy.gif&ct=g)
